### PR TITLE
Improve cpu frequency detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: rust
+rust:
+  - nightly
+os: linux
+dist: bionic
+before_install:
+  - sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+  - sudo adduser $USER libvirt
+  - sudo adduser $USER kvm
+  - cargo install cargo-download
+  - rustup component add rust-src
+  - rustup component add llvm-tools-preview
+install:
+  - git clone https://github.com/hermitcore/rusty-hermit.git
+jobs:
+  include:
+    - stage: Test
+      script:
+        - cargo build
+        - cd rusty-hermit
+        - cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
+        - cd ..
+        # used to get terminal with new groups permissions while preserving own user
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 target/debug/uhyve rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo"
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 HERMIT_CPUS=2 target/debug/uhyve rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo"
+
+    -
+      script:
+        - cargo build --release
+        - cd rusty-hermit
+        - cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
+        - cd ..
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 target/release/uhyve rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo"
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 HERMIT_CPUS=2 target/release/uhyve rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ strum = "0.8.0"
 strum_macros = "0.8.0"
 gdb-protocol = "0.1"
 burst = "0.0.2"
+regex = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies.xhypervisor]
 version = "0.0.*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate burst;
 extern crate log;
 extern crate env_logger;
 extern crate raw_cpuid;
+extern crate regex;
 extern crate x86;
 
 #[macro_use]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -678,7 +678,9 @@ pub trait Vm {
 
 					let cpuid = CpuId::new();
 					let mhz: u32 = detect_freq_from_cpuid(&cpuid).unwrap_or_else(|_| {
+						debug!("Failed to detect from cpuid");
 						detect_freq_from_cpuid_hypervisor_info(&cpuid).unwrap_or_else(|_| {
+							debug!("Failed to detect from hypervisor_info");
 							detect_freq_from_cpu_brand_string(&cpuid).unwrap_or(0)
 						})
 					});
@@ -716,8 +718,11 @@ fn detect_freq_from_cpuid(cpuid: &CpuId) -> std::result::Result<u32, ()> {
 }
 
 fn detect_freq_from_cpuid_hypervisor_info(cpuid: &CpuId) -> std::result::Result<u32, ()> {
+	debug!("Trying to detect CPU frequency via cpuid hypervisor info");
 	let hypervisor_info = cpuid.get_hypervisor_info().ok_or(())?;
+	debug!("cpuid detected hypervisor: {:?}", hypervisor_info.identify());
 	let freq = hypervisor_info.tsc_frequency().ok_or(())?;
+	debug!("cpuid detected frequency of {} Hz from hypervisor", freq);
 	let mhz: u32 = freq / 1000000u32;
 	if mhz > 0 {
 		Ok(mhz)


### PR DESCRIPTION
Changes:

- Add CPU frequency detection via cpuid hypervisor detection method
- Add CPU frequency detection via parsing lscpu on linux. Tbis works on travis (ubuntu bionic)
- Refactored detect_freq_from_cpu_brand_string to work similar to new detection methods
- Add travis CI config to test if rusty-demo runs on top of uhyve.

Things to look at:
- Commit  d1e44b7 - VM Parse CPU frequency.... -> I find the code there to be a bit ugly since I wasn't able to use the `?` operator. I got errors saying that the cast from the specific error classes to `()` are not implemented. Is there any way to get around this? I would have thought that casting an Error to `()` would be trivial.