### PR TITLE
ignore halt state => kernel switch in polling mode

### DIFF
--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -299,7 +299,7 @@ impl VirtualCPU for UhyveCPU {
 			match exitreason {
 				VcpuExit::Hlt => {
 					debug!("Halt Exit");
-					break;
+					// currently, we ignore the hlt state
 				}
 				VcpuExit::Shutdown => {
 					self.print_registers();


### PR DESCRIPTION
- currently only the idle loop is using the hlt instruction
- if we ignore the instruction, the idle loop get computation times
=> is active waiting for a new task