### PR TITLE
CI: Print version of dependencies to logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
   - rustup component add llvm-tools-preview
 install:
   - git clone https://github.com/hermitcore/rusty-hermit.git
+  - cd rusty-hermit && echo "rusty-hermit at commit $(git rev-parse HEAD)" && cd ..
+  - rustc --version
+  - cargo --version
 jobs:
   include:
     - stage: Test


### PR DESCRIPTION
Print the version of rustc, cargo and rusty-hermit so that the information is in the logfile