### PR TITLE
tun-tap: Exclude tokio dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,16 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,15 +122,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -216,17 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,34 +249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
-
-[[package]]
 name = "gdb-protocol"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,15 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -426,15 +359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,59 +405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mio"
-version = "0.6.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
-dependencies = [
- "cfg-if",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -594,32 +465,6 @@ name = "oorandom"
 version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
-
-[[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api",
- "parking_lot_core",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "plain"
@@ -706,12 +551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +606,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
@@ -851,21 +684,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
 ]
 
 [[package]]
@@ -959,217 +777,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes",
- "futures",
- "mio",
- "num_cpus",
- "tokio-codec",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
- "tokio-reactor",
- "tokio-sync",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "tokio-udp",
- "tokio-uds",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes",
- "futures",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
-dependencies = [
- "bytes",
- "futures",
- "iovec",
- "log",
- "mio",
- "scoped-tls",
- "tokio",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-timer",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-dependencies = [
- "futures",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils",
- "futures",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
-dependencies = [
- "futures",
- "tokio-io",
- "tokio-threadpool",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes",
- "futures",
- "log",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils",
- "futures",
- "lazy_static",
- "log",
- "mio",
- "num_cpus",
- "parking_lot",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes",
- "futures",
- "iovec",
- "mio",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils",
- "futures",
- "lazy_static",
- "log",
- "num_cpus",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-dependencies = [
- "crossbeam-utils",
- "futures",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "mio",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
-dependencies = [
- "bytes",
- "futures",
- "iovec",
- "libc",
- "log",
- "mio",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
 name = "tun-tap"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ccbe9cfffdaa7eefd36538bb26f228d4bd319a8aeca044d54377612a646bcd"
 dependencies = [
  "cc",
- "futures",
- "libc",
- "mio",
- "tokio-core",
 ]
 
 [[package]]
@@ -1367,16 +980,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "x86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ version = ">=0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies.tun-tap]
 version = "0.1.2"
+default-features = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
 version = "0.*"


### PR DESCRIPTION
While compiling uhyve, I noticed compiling Tokio, which takes a while.

Tokio is included in the dependency tree via the default `tokio` feature of `tun-tap`. As uhyve does not contain any `async` code, I disabled `tun-tap`'s default features, removing Tokio from the dependency tree.

The result should be noticeably faster compile times.

What do you think?

This is the dependency tree difference:
```diff
--- before	2020-09-21 10:25:46.766871951 +0200
+++ after	2020-09-21 10:25:38.547841407 +0200
@@ -89,145 +89,6 @@
 │       │   └── unicode-xid v0.0.4
 │       └── unicode-xid v0.0.4
 ├── tun-tap v0.1.2
-│   ├── futures v0.1.29
-│   ├── libc v0.2.76
-│   ├── mio v0.6.22
-│   │   ├── cfg-if v0.1.10
-│   │   ├── iovec v0.1.4
-│   │   │   └── libc v0.2.76
-│   │   ├── libc v0.2.76
-│   │   ├── log v0.4.11 (*)
-│   │   ├── net2 v0.2.35
-│   │   │   ├── cfg-if v0.1.10
-│   │   │   └── libc v0.2.76
-│   │   └── slab v0.4.2
-│   └── tokio-core v0.1.17
-│       ├── bytes v0.4.12
-│       │   ├── byteorder v1.3.4
-│       │   └── iovec v0.1.4 (*)
-│       ├── futures v0.1.29
-│       ├── iovec v0.1.4 (*)
-│       ├── log v0.4.11 (*)
-│       ├── mio v0.6.22 (*)
-│       ├── scoped-tls v0.1.2
-│       ├── tokio v0.1.22
-│       │   ├── bytes v0.4.12 (*)
-│       │   ├── futures v0.1.29
-│       │   ├── mio v0.6.22 (*)
-│       │   ├── num_cpus v1.13.0
-│       │   │   └── libc v0.2.76
-│       │   ├── tokio-codec v0.1.2
-│       │   │   ├── bytes v0.4.12 (*)
-│       │   │   ├── futures v0.1.29
-│       │   │   └── tokio-io v0.1.13
-│       │   │       ├── bytes v0.4.12 (*)
-│       │   │       ├── futures v0.1.29
-│       │   │       └── log v0.4.11 (*)
-│       │   ├── tokio-current-thread v0.1.7
-│       │   │   ├── futures v0.1.29
-│       │   │   └── tokio-executor v0.1.10
-│       │   │       ├── crossbeam-utils v0.7.2
-│       │   │       │   ├── cfg-if v0.1.10
-│       │   │       │   └── lazy_static v1.4.0
-│       │   │       │   [build-dependencies]
-│       │   │       │   └── autocfg v1.0.1
-│       │   │       └── futures v0.1.29
-│       │   ├── tokio-executor v0.1.10 (*)
-│       │   ├── tokio-fs v0.1.7
-│       │   │   ├── futures v0.1.29
-│       │   │   ├── tokio-io v0.1.13 (*)
-│       │   │   └── tokio-threadpool v0.1.18
-│       │   │       ├── crossbeam-deque v0.7.3
-│       │   │       │   ├── crossbeam-epoch v0.8.2
-│       │   │       │   │   ├── cfg-if v0.1.10
-│       │   │       │   │   ├── crossbeam-utils v0.7.2 (*)
-│       │   │       │   │   ├── lazy_static v1.4.0
-│       │   │       │   │   ├── maybe-uninit v2.0.0
-│       │   │       │   │   ├── memoffset v0.5.5
-│       │   │       │   │   │   [build-dependencies]
-│       │   │       │   │   │   └── autocfg v1.0.1
-│       │   │       │   │   └── scopeguard v1.1.0
-│       │   │       │   │   [build-dependencies]
-│       │   │       │   │   └── autocfg v1.0.1
-│       │   │       │   ├── crossbeam-utils v0.7.2 (*)
-│       │   │       │   └── maybe-uninit v2.0.0
-│       │   │       ├── crossbeam-queue v0.2.3
-│       │   │       │   ├── cfg-if v0.1.10
-│       │   │       │   ├── crossbeam-utils v0.7.2 (*)
-│       │   │       │   └── maybe-uninit v2.0.0
-│       │   │       ├── crossbeam-utils v0.7.2 (*)
-│       │   │       ├── futures v0.1.29
-│       │   │       ├── lazy_static v1.4.0
-│       │   │       ├── log v0.4.11 (*)
-│       │   │       ├── num_cpus v1.13.0 (*)
-│       │   │       ├── slab v0.4.2
-│       │   │       └── tokio-executor v0.1.10 (*)
-│       │   ├── tokio-io v0.1.13 (*)
-│       │   ├── tokio-reactor v0.1.12
-│       │   │   ├── crossbeam-utils v0.7.2 (*)
-│       │   │   ├── futures v0.1.29
-│       │   │   ├── lazy_static v1.4.0
-│       │   │   ├── log v0.4.11 (*)
-│       │   │   ├── mio v0.6.22 (*)
-│       │   │   ├── num_cpus v1.13.0 (*)
-│       │   │   ├── parking_lot v0.9.0
-│       │   │   │   ├── lock_api v0.3.4
-│       │   │   │   │   └── scopeguard v1.1.0
-│       │   │   │   └── parking_lot_core v0.6.2
-│       │   │   │       ├── cfg-if v0.1.10
-│       │   │   │       ├── libc v0.2.76
-│       │   │   │       └── smallvec v0.6.13
-│       │   │   │           └── maybe-uninit v2.0.0
-│       │   │   │       [build-dependencies]
-│       │   │   │       └── rustc_version v0.2.3 (*)
-│       │   │   │   [build-dependencies]
-│       │   │   │   └── rustc_version v0.2.3 (*)
-│       │   │   ├── slab v0.4.2
-│       │   │   ├── tokio-executor v0.1.10 (*)
-│       │   │   ├── tokio-io v0.1.13 (*)
-│       │   │   └── tokio-sync v0.1.8
-│       │   │       ├── fnv v1.0.7
-│       │   │       └── futures v0.1.29
-│       │   ├── tokio-sync v0.1.8 (*)
-│       │   ├── tokio-tcp v0.1.4
-│       │   │   ├── bytes v0.4.12 (*)
-│       │   │   ├── futures v0.1.29
-│       │   │   ├── iovec v0.1.4 (*)
-│       │   │   ├── mio v0.6.22 (*)
-│       │   │   ├── tokio-io v0.1.13 (*)
-│       │   │   └── tokio-reactor v0.1.12 (*)
-│       │   ├── tokio-threadpool v0.1.18 (*)
-│       │   ├── tokio-timer v0.2.13
-│       │   │   ├── crossbeam-utils v0.7.2 (*)
-│       │   │   ├── futures v0.1.29
-│       │   │   ├── slab v0.4.2
-│       │   │   └── tokio-executor v0.1.10 (*)
-│       │   ├── tokio-udp v0.1.6
-│       │   │   ├── bytes v0.4.12 (*)
-│       │   │   ├── futures v0.1.29
-│       │   │   ├── log v0.4.11 (*)
-│       │   │   ├── mio v0.6.22 (*)
-│       │   │   ├── tokio-codec v0.1.2 (*)
-│       │   │   ├── tokio-io v0.1.13 (*)
-│       │   │   └── tokio-reactor v0.1.12 (*)
-│       │   └── tokio-uds v0.2.7
-│       │       ├── bytes v0.4.12 (*)
-│       │       ├── futures v0.1.29
-│       │       ├── iovec v0.1.4 (*)
-│       │       ├── libc v0.2.76
-│       │       ├── log v0.4.11 (*)
-│       │       ├── mio v0.6.22 (*)
-│       │       ├── mio-uds v0.6.8
-│       │       │   ├── iovec v0.1.4 (*)
-│       │       │   ├── libc v0.2.76
-│       │       │   └── mio v0.6.22 (*)
-│       │       ├── tokio-codec v0.1.2 (*)
-│       │       ├── tokio-io v0.1.13 (*)
-│       │       └── tokio-reactor v0.1.12 (*)
-│       ├── tokio-executor v0.1.10 (*)
-│       ├── tokio-io v0.1.13 (*)
-│       ├── tokio-reactor v0.1.12 (*)
-│       └── tokio-timer v0.2.13 (*)
 │   [build-dependencies]
 │   └── cc v1.0.59
 ├── virtio-bindings v0.1.0
@@ -268,7 +129,24 @@
     ├── plotters v0.2.15
     │   └── num-traits v0.2.12 (*)
     ├── rayon v1.4.0
-    │   ├── crossbeam-deque v0.7.3 (*)
+    │   ├── crossbeam-deque v0.7.3
+    │   │   ├── crossbeam-epoch v0.8.2
+    │   │   │   ├── cfg-if v0.1.10
+    │   │   │   ├── crossbeam-utils v0.7.2
+    │   │   │   │   ├── cfg-if v0.1.10
+    │   │   │   │   └── lazy_static v1.4.0
+    │   │   │   │   [build-dependencies]
+    │   │   │   │   └── autocfg v1.0.1
+    │   │   │   ├── lazy_static v1.4.0
+    │   │   │   ├── maybe-uninit v2.0.0
+    │   │   │   ├── memoffset v0.5.5
+    │   │   │   │   [build-dependencies]
+    │   │   │   │   └── autocfg v1.0.1
+    │   │   │   └── scopeguard v1.1.0
+    │   │   │   [build-dependencies]
+    │   │   │   └── autocfg v1.0.1
+    │   │   ├── crossbeam-utils v0.7.2 (*)
+    │   │   └── maybe-uninit v2.0.0
     │   ├── either v1.6.0
     │   └── rayon-core v1.8.0
     │       ├── crossbeam-channel v0.4.4
@@ -277,7 +155,8 @@
     │       ├── crossbeam-deque v0.7.3 (*)
     │       ├── crossbeam-utils v0.7.2 (*)
     │       ├── lazy_static v1.4.0
-    │       └── num_cpus v1.13.0 (*)
+    │       └── num_cpus v1.13.0
+    │           └── libc v0.2.76
     │   [build-dependencies]
     │   └── autocfg v1.0.1
     ├── regex v1.3.9 (*)
```