### PR TITLE
add support of non-relocatable binaries

### DIFF
--- a/src/macos/vcpu.rs
+++ b/src/macos/vcpu.rs
@@ -597,6 +597,11 @@ impl VirtualCPU for UhyveCPU {
 						return Err(Error::InternalError);
 					}
 				}
+				vmx_exit::VMX_REASON_TRIPLE_FAULT => {
+					error!("Triple fault! System crashed!");
+					self.print_registers();
+					return Err(Error::UnhandledExitReason);
+				}
 				vmx_exit::VMX_REASON_CPUID => {
 					self.emulate_cpuid(rip)?;
 				}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -635,6 +635,7 @@ pub trait Vm {
 
 		// load kernel and determine image size
 		let vm_slice = std::slice::from_raw_parts_mut(vm_mem, vm_mem_length);
+		let mut image_size = 0;
 		elf.program_headers
 			.iter()
 			.try_for_each(|program_header| match program_header.p_type {
@@ -666,9 +667,14 @@ pub trait Vm {
 						*i = 0
 					}
 
+					image_size = if is_dyn {
+						program_header.p_vaddr + program_header.p_memsz
+					} else {
+						image_size + program_header.p_memsz
+					};
 					write(
 						&mut (*boot_info).image_size,
-						program_header.p_vaddr + program_header.p_memsz,
+						image_size,
 					);
 
 					Ok(())

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -545,9 +545,8 @@ pub trait Vm {
 		}
 
 		// Verify that this module is a HermitCore ELF executable.
-		if elf.header.e_type != ET_DYN {
-			return Err(Error::InvalidFile(self.kernel_path().into()));
-		}
+
+		let is_dyn = elf.header.e_type == ET_DYN;
 
 		if elf.header.e_machine != EM_X86_64 {
 			return Err(Error::InvalidFile(self.kernel_path().into()));
@@ -576,10 +575,16 @@ pub trait Vm {
 			write(&mut (*boot_info).hcmask, mask.octets());
 		}
 
-		// TODO: should be a random start address
-		let start_address: u64 = 0x400000;
-		self.set_entry_point(start_address + elf.entry);
-		debug!("ELF entry point at 0x{:x}", start_address + elf.entry);
+		let (start_address, elf_entry) = if is_dyn {
+			// TODO: should be a random start address, if we have a relocatable executable
+			(0x400000u64, 0x400000u64 + elf.entry)
+		} else {
+			// default location of a non-relocatable binary
+			(0x800000u64, elf.entry)
+		};
+
+		self.set_entry_point(elf_entry);
+		debug!("ELF entry point at 0x{:x}", elf_entry);
 
 		debug!("Set HermitCore header at 0x{:x}", BOOT_INFO_ADDR as usize);
 		self.set_boot_info(boot_info);
@@ -634,7 +639,11 @@ pub trait Vm {
 			.iter()
 			.try_for_each(|program_header| match program_header.p_type {
 				PT_LOAD => {
-					let region_start = (start_address + program_header.p_vaddr) as usize;
+					let region_start = if is_dyn {
+						(start_address + program_header.p_vaddr) as usize
+					} else {
+						program_header.p_vaddr as usize
+					};
 					let region_end = region_start + program_header.p_filesz as usize;
 					let kernel_start = program_header.p_offset as usize;
 					let kernel_end = kernel_start + program_header.p_filesz as usize;
@@ -667,10 +676,13 @@ pub trait Vm {
 				PT_TLS => {
 					// determine TLS section
 					debug!("Found TLS section with size {}", program_header.p_memsz);
-					write(
-						&mut (*boot_info).tls_start,
-						start_address + program_header.p_vaddr,
-					);
+					let tls_start = if is_dyn {
+						start_address + program_header.p_vaddr
+					} else {
+						program_header.p_vaddr
+					};
+
+					write(&mut (*boot_info).tls_start, tls_start);
 					write(&mut (*boot_info).tls_filesz, program_header.p_filesz);
 					write(&mut (*boot_info).tls_memsz, program_header.p_memsz);
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -545,6 +545,9 @@ pub trait Vm {
 		}
 
 		let is_dyn = elf.header.e_type == ET_DYN;
+		if is_dyn {
+			debug!("ELF file is a shared object file");
+		}
 
 		if elf.header.e_machine != EM_X86_64 {
 			return Err(Error::InvalidFile(self.kernel_path().into()));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -544,8 +544,6 @@ pub trait Vm {
 			return Err(Error::InvalidFile(self.kernel_path().into()));
 		}
 
-		// Verify that this module is a HermitCore ELF executable.
-
 		let is_dyn = elf.header.e_type == ET_DYN;
 
 		if elf.header.e_machine != EM_X86_64 {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -673,10 +673,7 @@ pub trait Vm {
 					} else {
 						image_size + program_header.p_memsz
 					};
-					write(
-						&mut (*boot_info).image_size,
-						image_size,
-					);
+					write(&mut (*boot_info).image_size, image_size);
 
 					Ok(())
 				}


### PR DESCRIPTION
Currently, C-based applications (see [hermit-playground](https://github.com/hermitcore/hermit-playground)) are not relocatable. Consequently, the loader has to support relocatable and non-relocatable applications.