### PR TITLE
Allow kernel arguments to begin with a hyphen

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -23,6 +23,8 @@ fn main() {
 
 	let matches = App::new("uhyve")
 		.version(crate_version!())
+		.setting(clap::AppSettings::TrailingVarArg)
+		.setting(clap::AppSettings::AllowLeadingHyphen)
 		.author(crate_authors!("\n"))
 		.about("A minimal hypervisor for RustyHermit")
 		.arg(


### PR DESCRIPTION
The current uhyve argument parser does not specify that flags meant for uhyve should not be parsed following the kernel argument. Therefore, any argument to the kernel beginning with a hyphen is instead treated as an argument to uhyve, throwing an error. 

In other words: 
`uhyve kernel --verbose` currently parses the `--verbose` flag, enables the verbose setting in uhyve, and executes the kernel with **no arguments**. There is currently no way to give an argument to the kernel if it accepts a `--verbose` flag itself. This patch makes it so that the example command will instead pass the `--verbose` flag onto the kernel.

Note that this extends to any kernel argument beginning with a hyphen. If the user were to execute `uhyve kernel --foo`, uhyve would throw an error (since "foo" is not defined as a flag for uhyve) rather than execute the kernel with argument `--foo`.

If this PR is merged, any flags the user means to pass to uhyve should be passed before the kernel file path, and any flags after the kernel file path are passed straight to the kernel. This is better because it matches the specification given by `uhyve --help`. 

From `uhyve --help`:
```
USAGE:
    uhyve [FLAGS] [OPTIONS] <KERNEL> [ARGUMENTS]...
```

I'm not sure if this change could break some command sequence somewhere, but assuming it does not, I believe this is the desired behavior. (Alternatively, we could specify somewhere for the user to use the -- token which clap supports, i.e. `uhyve kernel -- --foo`)

https://docs.rs/clap/2.33.1/clap/enum.AppSettings.html#variant.TrailingVarArg
https://docs.rs/clap/2.33.1/clap/enum.AppSettings.html#variant.AllowLeadingHyphen