### PR TITLE
Fixed 3 clippy warnings + updated dependencies 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20fd25aa456527ce4f544271ae4fea65d2eda4a6561ea56f39fb3ee4f7e3884"
+checksum = "c69552f48b18aa6102ce0c82dd9bc9d3f8af5fc0a5797069b1b466b90570e39c"
 dependencies = [
  "log",
  "plain",
@@ -286,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,12 +305,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "itertools"
@@ -348,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99720f5df3814a7188f095ad6774775b7635dfdd62b7c091ce7e00a51c3c109"
+checksum = "158d15da895bddca8223fa31dc9e8b9317bdc2fbc4635dea8dd575fc40dae37f"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -380,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "mac_address"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f46c2dbc73bb2fc1e252690792572d581bb1fcf9b5d19cf3b678ce86ac3f05c"
+checksum = "6d9bb26482176bddeea173ceaa2acec85146d20cdcc631eafaf9d605d3d4fc23"
 dependencies = [
  "nix",
  "winapi 0.3.9",
@@ -414,13 +420,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -482,20 +488,8 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -621,8 +615,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12bd20b94c7cdfda8c7ba9b92ad0d9a56e3fa018c25fca83b51aa664c9b4c0d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.54",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -663,8 +657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.54",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -686,29 +680,20 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strum"
-version = "0.8.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca6e4730f517e041e547ffe23d29daab8de6b73af4b6ae2a002108169f5e7da"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 
 [[package]]
 name = "strum_macros"
-version = "0.8.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3384590878eb0cab3b128e844412e2d010821e7e091211b9d87324173ada7db8"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -718,17 +703,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -810,16 +786,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -880,8 +856,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.54",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -891,7 +867,7 @@ version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -902,8 +878,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.54",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,52 +27,52 @@ name = "uhyve"
 path = "src/bin/uhyve.rs"
 
 [dependencies]
-log = "0.4"
-env_logger = "0.7"
-aligned_alloc = "0.1"
-lazy_static = "1.4"
-clap = "2"
-raw-cpuid = "8.1"
-bitflags = "1.2"
-libc = "0.2"
-nix = "0.18"
-virtio-bindings = { version = "0.1", features = ["virtio-v4_14_0"]}
-mac_address = "1.0.*"
-rustc-serialize = "0.3"
-byteorder = "1"
-nom = "3.2.0"
-strum = "0.8.0"
-strum_macros = "0.8.0"
-gdb-protocol = "0.1"
+log = "0.4.11"
+env_logger = "0.8.2"
+aligned_alloc = "0.1.3"
+lazy_static = "1.4.0"
+clap = "2.33.3"
+raw-cpuid = "8.1.2"
+bitflags = "1.2.1"
+libc = "0.2.81"
+nix = "0.19.1"
+virtio-bindings = { version = "0.1.0", features = ["virtio-v4_14_0"]}
+mac_address = "1.1.1"
+rustc-serialize = "0.3.24"
+byteorder = "1.3.4"
+nom = "3.2.1"
+strum = "0.20.0"
+strum_macros = "0.20.1"
+gdb-protocol = "0.1.0"
 burst = "0.0.2"
 
 [dependencies.goblin]
-version = "0.2"
+version = "0.3.0"
 default-features = false
 features = ["elf64", "elf32", "endian_fd", "std"]
 
 [target.'cfg(target_os = "macos")'.dependencies.xhypervisor]
-version = "0.0.*"
+version = "0.0.12"
 
 [target.'cfg(target_os = "linux")'.dependencies.kvm-ioctls]
-version = "0.5.*"
+version = "0.6.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.kvm-bindings]
-version = "0.*"
+version = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.vmm-sys-util]
-version = ">=0.2.1"
+version = "0.7.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.tun-tap]
 version = "0.1.2"
 default-features = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
-version = "0.*"
+version = "0.34.0"
 default-features = false
 
 [dev-dependencies]
-criterion = "0.3.2"
+criterion = "0.3.3"
 
 [[bench]]
 name = "benchmarks"

--- a/src/linux/uhyve.rs
+++ b/src/linux/uhyve.rs
@@ -204,9 +204,11 @@ impl Uhyve {
 		vm.create_irq_chip().or_else(to_error)?;
 
 		// enable x2APIC support
-		let mut cap: kvm_enable_cap = Default::default();
-		cap.cap = KVM_CAP_X2APIC_API;
-		cap.flags = 0;
+		let mut cap: kvm_enable_cap = kvm_bindings::kvm_enable_cap {
+			cap: KVM_CAP_X2APIC_API,
+			flags: 0,
+			..Default::default()
+		};
 		cap.args[0] =
 			(KVM_X2APIC_API_USE_32BIT_IDS | KVM_X2APIC_API_DISABLE_BROADCAST_QUIRK) as u64;
 		vm.enable_cap(&cap)
@@ -214,15 +216,19 @@ impl Uhyve {
 
 		// currently, we support only system, which provides the
 		// cpu feature TSC_DEADLINE
-		let mut cap: kvm_enable_cap = Default::default();
-		cap.cap = KVM_CAP_TSC_DEADLINE_TIMER;
+		let mut cap: kvm_enable_cap = kvm_bindings::kvm_enable_cap {
+			cap: KVM_CAP_TSC_DEADLINE_TIMER,
+			..Default::default()
+		};
 		cap.args[0] = 0;
 		if vm.enable_cap(&cap).is_ok() {
 			panic!("Processor feature \"tsc deadline\" isn't supported!")
 		}
 
-		let mut cap: kvm_enable_cap = Default::default();
-		cap.cap = KVM_CAP_IRQFD;
+		let cap: kvm_enable_cap = kvm_bindings::kvm_enable_cap {
+			cap: KVM_CAP_IRQFD,
+			..Default::default()
+		};
 		if vm.enable_cap(&cap).is_ok() {
 			panic!("The support of KVM_CAP_IRQFD is curently required");
 		}


### PR DESCRIPTION
I came across deps.rs and saw that it lists outdated packages for uhyve: https://deps.rs/crate/uhyve/0.0.24