### PR TITLE
Improve Hugepage detection and parameters

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -34,7 +34,7 @@ fn main() {
 				.help("Print also kernel messages"),
 		)
 		.arg(
-			Arg::with_name("HUGEPAGE")
+			Arg::with_name("DISABLE_HUGEPAGE")
 				.long("disable-hugepages")
 				.help("Disable the usage of huge pages"),
 		)
@@ -154,10 +154,10 @@ fn main() {
 		mergeable = true;
 	}
 	// per default we use huge page to improve the performace
-	// => negate the result of parase_bool
+	// => negate the result of parse_bool
 	let mut hugepage: bool = !utils::parse_bool("HERMIT_HUGEPAGE", false);
-	if matches.is_present("HUGEPAGE") {
-		hugepage = true;
+	if matches.is_present("DISABLE_HUGEPAGE") {
+		hugepage = false;
 	}
 	let mut verbose: bool = utils::parse_bool("HERMIT_VERBOSE", false);
 	if matches.is_present("VERBOSE") {

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -154,8 +154,7 @@ fn main() {
 		mergeable = true;
 	}
 	// per default we use huge page to improve the performace
-	// => negate the result of parse_bool
-	let mut hugepage: bool = !utils::parse_bool("HERMIT_HUGEPAGE", false);
+	let mut hugepage: bool = utils::parse_bool("HERMIT_HUGEPAGE", true);
 	if matches.is_present("DISABLE_HUGEPAGE") {
 		hugepage = false;
 	}

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -153,8 +153,12 @@ fn main() {
 	if matches.is_present("MERGEABLE") {
 		mergeable = true;
 	}
-	// per default we use huge page to improve the performace
-	let mut hugepage: bool = utils::parse_bool("HERMIT_HUGEPAGE", true);
+	// per default we use huge page to improve the performace,
+	// if the kernel supports transparent hugepages
+	let hugepage_default = utils::transparent_hugepages_available().unwrap_or(true);
+	println!("Default hugepages set to: {}", hugepage_default);
+	// HERMIT_HUGEPAGES overrides the default we detected.
+	let mut hugepage: bool = utils::parse_bool("HERMIT_HUGEPAGE", hugepage_default);
 	if matches.is_present("DISABLE_HUGEPAGE") {
 		hugepage = false;
 	}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,8 +24,8 @@ pub fn parse_u32(s: &str) -> Result<u32> {
 }
 
 /// Helper function for `parse_bool`
-fn parse_bool_str(name: &str) -> Option<bool> {
-	match name.to_ascii_lowercase().as_ref() {
+fn parse_bool_str(value: &str) -> Option<bool> {
+	match value.to_ascii_lowercase().as_ref() {
 		"true" | "yes" => Some(true),
 		"false" | "no" => Some(false),
 		_ => None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
-use std::env;
 use log::debug;
+use std::env;
 
 pub fn parse_mem(mem: &str) -> Result<usize> {
 	let (num, postfix): (String, String) = mem.chars().partition(|&x| x.is_numeric());
@@ -26,16 +26,17 @@ pub fn parse_u32(s: &str) -> Result<u32> {
 /// Helper function for `parse_bool`
 fn parse_bool_str(name: &str) -> Option<bool> {
 	match name {
-	    "True"  | "true"  | "Yes" | "yes" => Some(true),
-	    "False" | "false" | "No"  | "no"  => Some(false),
-	    _ => None,
+		"True" | "true" | "Yes" | "yes" => Some(true),
+		"False" | "false" | "No" | "no" => Some(false),
+		_ => None,
 	}
 }
 
 pub fn parse_bool(name: &str, default: bool) -> bool {
 	env::var(name)
-		.map(|x| parse_bool_str(x.as_ref())
-			.unwrap_or(x.parse::<i32>().unwrap_or(default as i32) != 0))
+		.map(|x| {
+			parse_bool_str(x.as_ref()).unwrap_or(x.parse::<i32>().unwrap_or(default as i32) != 0)
+		})
 		.unwrap_or(default)
 }
 
@@ -55,25 +56,36 @@ pub fn get_max_subslice(s: &str, offset: usize, length: usize) -> &str {
 /// If there is an error when reading the file or interpreting the
 /// contents we return an Err and let the caller decide
 pub fn transparent_hugepages_available() -> std::result::Result<bool, ()> {
-	let transp_hugepage_enabled = std::path::Path::new("/sys/kernel/mm/transparent_hugepage/enabled");
-	if ! transp_hugepage_enabled.is_file() {
-		debug!("`{}` does not exist. Assuming Hugepages are not available", transp_hugepage_enabled.display());
+	let transp_hugepage_enabled =
+		std::path::Path::new("/sys/kernel/mm/transparent_hugepage/enabled");
+	if !transp_hugepage_enabled.is_file() {
+		debug!(
+			"`{}` does not exist. Assuming Hugepages are not available",
+			transp_hugepage_enabled.display()
+		);
 		Ok(false)
 	} else {
 		let str_res = std::fs::read_to_string(transp_hugepage_enabled);
 		if str_res.is_err() {
-			debug!("transparent_hugepages_available: Error reading string: {:?}", str_res.unwrap_err());
+			debug!(
+				"transparent_hugepages_available: Error reading string: {:?}",
+				str_res.unwrap_err()
+			);
 			Err(())
-		}else{
+		} else {
 			match str_res.unwrap().trim() {
 				"[always] madvise never" => Ok(true),
 				"always [madvise] never" => Ok(true),
 				"always madvise [never]" => Ok(false),
-				s => {debug!("Could not interpret contents of {}: {}",
-					transp_hugepage_enabled.display(), s); 
-					Err(())},
+				s => {
+					debug!(
+						"Could not interpret contents of {}: {}",
+						transp_hugepage_enabled.display(),
+						s
+					);
+					Err(())
+				}
 			}
 		}
-		
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,7 +31,7 @@ fn parse_bool_str(value: &str) -> Option<bool> {
 		"true" | "yes" => Some(true),
 		"false" | "no" => Some(false),
 		_ => None,
-  }
+	}
 }
 
 /// Returns a Vec of u32 as specified in the inclusive range s

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,9 +25,9 @@ pub fn parse_u32(s: &str) -> Result<u32> {
 
 /// Helper function for `parse_bool`
 fn parse_bool_str(name: &str) -> Option<bool> {
-	match name {
-		"True" | "true" | "Yes" | "yes" => Some(true),
-		"False" | "false" | "No" | "no" => Some(false),
+	match name.to_ascii_lowercase().as_ref() {
+		"true" | "yes" => Some(true),
+		"false" | "no" => Some(false),
 		_ => None,
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,9 +22,19 @@ pub fn parse_u32(s: &str) -> Result<u32> {
 	s.parse::<u32>().map_err(|_| Error::ParseMemory)
 }
 
+/// Helper function for `parse_bool`
+fn parse_bool_str(name: &str) -> Option<bool> {
+	match name {
+	    "True"  | "true"  | "Yes" | "yes" => Some(true),
+	    "False" | "false" | "No"  | "no"  => Some(false),
+	    _ => None,
+	}
+}
+
 pub fn parse_bool(name: &str, default: bool) -> bool {
 	env::var(name)
-		.map(|x| x.parse::<i32>().unwrap_or(default as i32) != 0)
+		.map(|x| parse_bool_str(x.as_ref())
+			.unwrap_or(x.parse::<i32>().unwrap_or(default as i32) != 0))
 		.unwrap_or(default)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,6 +55,7 @@ pub fn get_max_subslice(s: &str, offset: usize, length: usize) -> &str {
 /// then we assume there is no support.
 /// If there is an error when reading the file or interpreting the
 /// contents we return an Err and let the caller decide
+#[cfg(target_os = "linux")]
 pub fn transparent_hugepages_available() -> std::result::Result<bool, ()> {
 	let transp_hugepage_enabled =
 		std::path::Path::new("/sys/kernel/mm/transparent_hugepage/enabled");
@@ -88,4 +89,10 @@ pub fn transparent_hugepages_available() -> std::result::Result<bool, ()> {
 			}
 		}
 	}
+}
+
+/// On macos this always returns true
+#[cfg(target_os = "macos")]
+pub fn transparent_hugepages_available() -> std::result::Result<bool, ()> {
+	Ok(true)
 }


### PR DESCRIPTION
The first few commits clean up how hugepage support can be toggled from the Environment or via a parameter.
There was some mismatch between the name of the options and what it did, so the behaviour is now the following:
- `--disable-hugepages` now correctly disables hugepages. This overrides the Environment variable and any defaults
- `HERMIT_HUGEPAGE` now accepts True, true, False, false, Yes, yes, No, no and interprets them as boolean options. Additionally `HERMIT_HUGEPAGE=True` or `HERMIT_HUGEPAGE=1` now correctly enables hugepages.

Additionally the last commit attempts to detect support for transparent huge pages by parsing `sysfs`. This obviously is Linux only. A followup commit addressing MacOS is still required. @stlankes I'm leaning towards always enabling huge pages on MacOS. What do you think?