### PR TITLE
{WIP] Upgrade Nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ virtio-bindings = { version = "0.1.0", features = ["virtio-v4_14_0"]}
 mac_address = "1.1.1"
 rustc-serialize = "0.3.24"
 byteorder = "1.3.4"
-nom = "3.2.1"
+nom = "4.2.3"
 strum = "0.20.0"
 strum_macros = "0.20.1"
 gdb-protocol = "0.1.0"

--- a/src/gdb_parser.rs
+++ b/src/gdb_parser.rs
@@ -21,7 +21,7 @@ use gdb_protocol::io::BUF_SIZE;
 use log::{debug, info, trace};
 use nom::IResult::*;
 use nom::{
-	alt, alt_complete, call, complete, do_parse, error_position, flat_map, is_not, is_not_s, many0,
+	alt, alt_complete, call, complete, do_parse, error_position, flat_map, is_not, many0,
 	many1, map, map_res, named, one_of, opt, preceded, separated_list, separated_list_complete,
 	separated_nonempty_list, separated_nonempty_list_complete, separated_pair, tag, take,
 	take_till, take_while1, try_parse, tuple, tuple_parser,
@@ -340,7 +340,7 @@ enum Command<'a> {
 
 named!(
 	gdbfeature<Known>,
-	map!(map_res!(is_not_s!(";="), str::from_utf8), |s| {
+	map!(map_res!(is_not!(";="), str::from_utf8), |s| {
 		match GDBFeature::from_str(s) {
 			Ok(f) => Known::Yes(f),
 			Err(_) => Known::No(s),
@@ -386,7 +386,7 @@ named!(q_search_memory<&[u8], (u64, u64, Vec<u8>)>,
 named!(q_read_feature<&[u8], (&str, u64, u64)>,
 	   complete!(do_parse!(
 		   tag!("qXfer:features:read:") >>
-		   filename: map!(is_not_s!(":"), |s| std::str::from_utf8(s).unwrap()) >>
+		   filename: map!(is_not!(":"), |s| std::str::from_utf8(s).unwrap()) >>
 		   tag!(":") >>
 		   offset: hex_value >>
 		   tag!(",") >>


### PR DESCRIPTION
This is a WIP PR to upgrade nom to version 6. In the first step of this PR an upgrade to version 4 is attempted.
Once that's working I'll update with 5 and 6.
Nom is mostly (exclusively?) used in the file `gdb_server.rs`.
Before merging I'll squash the commits together, so git bisect doesn't get broken, but for the purpose of review, I've decided to use multiple commits replacing things.

Commit e8f1013  builds sucessfully, however most of the  tests are failing (gdb_parser).
I suspect this is mainly due to the `hex_value` function, which is broken, since it is used by many other failing tests.
The issue here is that for byte strings such as "aa", which would previously be parsed into the hex number, nom now returns an 
`Incomplete` error.
This is by design (see https://github.com/Geal/nom/blob/4.0.0/doc/upgrading_to_nom_4.md#dealing-with-incomplete-usage), and can be addressed by using the type `CompleteByteSlice` (in Nom 4) instead of `&[u8]`. 
Alternatively adding a non hex character to the slice, such as "aaU" also marks the slice as complete from the point of `hex_value`

However, this does of course raise the issue if all byte slices are guaranteed to be complete, or if in some cases we might 
expect `Incomplete` errors. 
@stlankes Could you give some insights, where we can expect complete byte slices, and where we have to deal with incomplete slices?