### PR TITLE
Add --affinity option to bind CPU threads to a specified host CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "core_affinity"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a03115cc34fb0d7c321dd154a3914b3ca082ccc5c11d91bf7117dbbe7171f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "num_cpus",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +774,7 @@ dependencies = [
  "burst",
  "byteorder",
  "clap",
+ "core_affinity",
  "criterion",
  "env_logger",
  "gdb-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ strum = "0.20.0"
 strum_macros = "0.20.1"
 gdb-protocol = "0.1.0"
 burst = "0.0.2"
+core_affinity = "0.5.10"
 
 [dependencies.goblin]
 version = "0.3.0"

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -14,6 +14,8 @@ use uhyvelib::vm;
 use uhyvelib::vm::Vm;
 
 use clap::{App, Arg};
+use core_affinity::CoreId;
+use uhyvelib::utils::{parse_cpu_affinity, parse_u32_range};
 
 const MINIMAL_GUEST_SIZE: usize = 16 * 1024 * 1024;
 const DEFAULT_GUEST_SIZE: usize = 64 * 1024 * 1024;
@@ -60,6 +62,19 @@ fn main() {
 				.help("Number of guest processors")
 				.takes_value(true)
 				.env("HERMIT_CPUS"),
+		)
+		.arg(
+			Arg::with_name("CPU_AFFINITY")
+				.short("a")
+				.long("affinity")
+				.value_name("cpulist")
+				.help("CPU Affinity of guest CPUs on Host")
+				.long_help(
+					"A list of CPUs delimited by commas onto which
+					 the virtual CPUs should be bound. This may improve 
+					performance.
+					",
+				),
 		)
 		.arg(
 			Arg::with_name("GDB_PORT")
@@ -144,6 +159,20 @@ fn main() {
 		.value_of("CPUS")
 		.map(|x| utils::parse_u32(&x).unwrap_or(1))
 		.unwrap_or(1);
+
+	let set_cpu_affinity = matches.is_present("CPU_AFFINITY");
+	let cpu_affinity: Option<Vec<core_affinity::CoreId>> = if set_cpu_affinity {
+		let args: Vec<&str> = matches
+			.values_of("CPU_AFFINITY")
+			.unwrap()
+			.into_iter()
+			.collect();
+		Some(
+			parse_cpu_affinity(args, num_cpus).expect("Invalid parameters for option CPU_AFFINITY"),
+		)
+	} else {
+		None
+	};
 	let ip = None; //matches.value_of("IP").or(None);
 	let gateway = None; // matches.value_of("GATEWAY").or(None);
 	let mask = None; //matches.value_of("MASK").or(None);
@@ -192,9 +221,21 @@ fn main() {
 		.map(|tid| {
 			let vm = vm.clone();
 
+			let local_cpu_affinity: Option<CoreId> = match &cpu_affinity {
+				Some(vec) => vec.get(tid as usize).cloned(),
+				None => None,
+			};
+
 			// create thread for each CPU
 			thread::spawn(move || {
 				debug!("Create thread for CPU {}", tid);
+				match local_cpu_affinity {
+					Some(core_id) => {
+						debug!("Trying to pin thread {} to CPU {}", tid, core_id.id);
+						core_affinity::set_for_current(core_id); // This does not return an error if it fails :(
+					}
+					None => debug!("No affinity specified, not binding thread"),
+				}
 
 				let mut cpu = vm.create_cpu(tid).unwrap();
 				cpu.init(vm.get_entry_point()).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
 	UnhandledExitReason,
 	InvalidMacAddress,
 	ParseIntError,
+	ParseRangeError,
+	InvalidArgument(String),
 	#[cfg(target_os = "macos")]
 	Hypervisor(xhypervisor::Error),
 }
@@ -58,6 +60,8 @@ impl fmt::Display for Error {
 			Error::UnhandledExitReason => write!(f, "Unhandled exit reason"),
 			Error::InvalidMacAddress => write!(f, "Invalid MAC address"),
 			Error::ParseIntError => write!(f, "Unable to parse string"),
+			Error::ParseRangeError => write!(f, "Unable to parse string range"),
+			Error::InvalidArgument(ref arg) => write!(f, "Invalid argument passed: {}", arg),
 			#[cfg(target_os = "macos")]
 			Error::Hypervisor(ref err) => write!(f, "The hypervisor has failed: {:?}", err),
 		}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,6 +22,33 @@ pub fn parse_u32(s: &str) -> Result<u32> {
 	s.parse::<u32>().map_err(|_| Error::ParseMemory)
 }
 
+/// Returns a Vec of u32 as specified in the inclusive range s
+/// s should only contain digits and a single `-`
+/// The second number should be greater than the first
+/// A single positive integer is also a valid parameter ( a range of length 1)
+/// Example:
+/// ```rust
+/// # use uhyvelib::utils::parse_u32_range;
+/// let s = "5-7";
+/// let range = parse_u32_range(s)?;
+/// assert_eq!(range, [5, 6, 7]);
+/// # Ok::<(), uhyvelib::error::Error>(())
+///  ```
+/// FIXME: this doesn't actually have to be a range, could also be single value
+pub fn parse_u32_range(s: &str) -> Result<Vec<u32>> {
+	let split: Vec<&str> = s.split('-').collect();
+	if split.len() == 1 {
+		let val = parse_u32(s)?;
+		let vec = vec![val; 1];
+		Ok(vec) // Into Vec containing a single u32
+	} else if split.len() == 2 {
+		let range: Vec<u32> = (parse_u32(split[0])?..=parse_u32(split[1])?).collect();
+		Ok(range)
+	} else {
+		Err(Error::InvalidArgument(String::from(s)))
+	}
+}
+
 pub fn parse_bool(name: &str, default: bool) -> bool {
 	env::var(name)
 		.map(|x| x.parse::<i32>().unwrap_or(default as i32) != 0)
@@ -35,5 +62,58 @@ pub fn get_max_subslice(s: &str, offset: usize, length: usize) -> &str {
 		&large[0..length]
 	} else {
 		large
+	}
+}
+
+/// This is a helper function to parse the arguments passed via the commandline argument
+/// --cpu_affinity
+/// FIXME move filtering to seperate function, to make tests cleaner
+pub fn parse_cpu_affinity(args: Vec<&str>, num_cpus: u32) -> Result<Vec<core_affinity::CoreId>> {
+	let mut affinity_params: Vec<u32> = Vec::new();
+	let _ = args
+		.into_iter()
+		.map(|s| parse_u32_range(s))
+		.map(|range| affinity_params.extend(range.expect("Invalid parameters for CPU_AFFINITY")));
+	affinity_params.sort();
+	affinity_params.dedup();
+	let affinity_params = affinity_params;
+
+	// According to https://github.com/Elzair/core_affinity_rs/issues/3
+	// on linux this gives a list of CPUs the process is allowed to run on
+	// (as opposed to all CPUs available on the system as the docs suggest)
+	let core_ids = core_affinity::get_core_ids().ok_or_else(|| Error::InternalError)?;
+	// Filter core_ids to contain only the CPUs specified by CPU_AFFINITY
+	let filtered_cpu_affinity: Vec<core_affinity::CoreId> = core_ids
+		.into_iter()
+		.filter(|core_id| affinity_params.contains(&(core_id.id as u32)))
+		.collect();
+	if filtered_cpu_affinity.len() == num_cpus as usize {
+		Ok(filtered_cpu_affinity)
+	} else {
+		Err(Error::InvalidArgument(String::from(
+			"When specifying the CPU affinity, a valid affinity must be specified for \
+		 				   every CPU that uhyve spawns",
+		)))
+	}
+}
+
+mod tests {
+	use crate::utils::*;
+
+	#[test]
+	fn test_parse_u32_range_valid() {
+		let str = "1-3";
+		assert_eq!(parse_u32_range(str).unwrap(), [1, 2, 3]);
+		let str = "0";
+		assert_eq!(parse_u32_range(str).unwrap(), [0]);
+		let str = "52364-52365";
+		assert_eq!(parse_u32_range(str).unwrap(), [52364, 52365]);
+	}
+
+	#[test]
+	#[should_panic]
+	fn test_parse_u32_range_invalid() {
+		let str = "-3";
+		parse_u32_range(str).unwrap();
 	}
 }


### PR DESCRIPTION
This uses the core_affinity crate to optionally bind the vCPU threads to a logical host CPU.
On MacOS this is apparently more of a hint.
The downside of using the core_affinity thread is that errors in `sched_setaffinity` are ignored. 
But since it appears to be working, I think this solution is fine for now. 

If I have some more time, maybe I'll use the libc functions directly and add appropriate error handling / reporting.

`-a` or `--affiity` takes a comma seperated list of logical CPUs or alternatively an inclusive range of logical CPUs.
Example `--affinity=1,3-5,9` would be valid and expands to the cpulist `1,3,4,5,9`.
The number of CPUs specified with `--affinity` must match the number specified with the `-c` option (default 1), otherwise an error is printed.

If `--affinity` is not specified, then the behaviour is unchanged and no thread is bound to any particular host CPU.