### PR TITLE
Fix bors timeouts

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,7 +4,7 @@ status = [
   "Format (ubuntu-latest, nightly)",
   "Test (ubuntu-latest, nightly)",
   "Test (macOS-latest, nightly)",
-  "ci/gitlab/git.rwth-aachen.de",
+  "ci/gitlab/%",
 ]
 delete_merged_branches = true
 timeout_sec = 7200


### PR DESCRIPTION
The name of the status of gitlab CI pipelines is inconsistent, so use a wildcard to match.
I'm not sure if this actually works, I'm basing this on the following:
https://forum.bors.tech/t/usage-with-gitlab-ci/245
and 
https://github.com/bors-ng/bors-ng/pull/547