### PR TITLE
Add code Coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
          submodules: true
+         fetch-depth: '2'
     - name: Check Cargo availability
       run: cargo --version
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
     - name: Test
       run:
          cargo test -- --nocapture
+    - name: Generate Test coverage
+      run: |
+        UHYVE_CODECOV_TOKEN="dummy" ./generate_test_coverage.sh
+        bash <(curl -s https://codecov.io/bash) -f ./coveralls.json
 
   build:
     name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
          submodules: true
-         fetch-depth: '2'
+         fetch-depth: '0'
     - name: Check Cargo availability
       run: cargo --version
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,11 @@ jobs:
          cargo test -- --nocapture
     - name: Generate Test coverage
       run: |
-        UHYVE_CODECOV_TOKEN="dummy" ./generate_test_coverage.sh
-        bash <(curl -s https://codecov.io/bash) -f ./coveralls.json
+        ./generate_test_coverage.sh
+        bash <(curl -s https://codecov.io/bash) -f 
+    - uses: codecov/codecov-action@v1
+      with:
+        files: ./coveralls.json
 
   build:
     name: Build

--- a/coverage_rustcwrapper.sh
+++ b/coverage_rustcwrapper.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Invoked by cargo
+# The first argument will be the path to rustc
+# The crate name is the argument after --crate-name
+
+# This searches for --crate-name in the parameters passed and echos the parameter after that
+# -> the name of the crate
+get_crate_name(){
+    # While there are still arguments left
+    while [[ $# -gt 1 ]]
+    do
+        if [ "$1" ==  "--crate-name" ];
+        then
+            echo "$2"
+            return
+        fi
+        shift 1     # shift arguments one to left, i.e. $2 becomes $1 etc.
+    done
+}
+
+case $(get_crate_name "$@") in
+    uhyve|uhyvelib)
+        EXTRA_OPTIONS=("-Zinstrument-coverage" "-Clink-dead-code")
+        ;;
+    *)
+        ;;
+esac
+
+exec "$@" "${EXTRA_OPTIONS[@]}"

--- a/generate_test_coverage.sh
+++ b/generate_test_coverage.sh
@@ -45,10 +45,11 @@ cargo clean
 echo "Running cargo test. This may take a while."
 
 # Run tests and collect information about the filenames of the executables in json format
+# The RUSTC_WRAPPER adds the coverage specific flags to our crate executables (which are not doc tests)
 TEST_JSON_OUTPUT="$(
-    RUSTFLAGS="-Zinstrument-coverage -Clink-dead-code" \
         RUSTDOCFLAGS="-Zinstrument-coverage -Zunstable-options --persist-doctests  target/debug/doctestbins" \
         LLVM_PROFILE_FILE="uhyve-%m.profraw" \
+        RUSTC_WRAPPER="$DIR/coverage_rustcwrapper.sh" \
         cargo test --message-format=json
 )"
 if [ $? != 0 ]; then

--- a/generate_test_coverage.sh
+++ b/generate_test_coverage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Important note: This currently requires $CODECOV_TOKEN to be set before calling this
+# Important note: This currently requires $UHYVE_CODECOV_TOKEN to be set before calling this
 # I'm ti
 exit_with_error() {
     echo "Error: $*"
@@ -62,7 +62,7 @@ cargo profdata -- merge -sparse uhyve-*.profraw -o uhyve.profdata \
 grcov "$DIR" --source-dir "$DIR" \
     --binary-path "$DIR/target/debug" \
     --output-type coveralls \
-    --token "$CODECOV_TOKEN" > coveralls.json \
+    --token "$UHYVE_CODECOV_TOKEN" > coveralls.json \
  || exit_with_error "grcov did not successfully generate a coverage report"
 
 # Todo: make this whole part optional, since we might be only interested in coveralls report

--- a/generate_test_coverage.sh
+++ b/generate_test_coverage.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Important note: This currently requires $UHYVE_CODECOV_TOKEN to be set before calling this
-# I'm ti
+
 exit_with_error() {
     echo "Error: $*"
     exit 1
 }
 # from https://stackoverflow.com/a/246128
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+UHYVE_CODECOV_TOKEN="${UHYVE_CODECOV_TOKEN:-dummytoken}"    # Set dummy token, if no token passed (for grcov)
 
 if ! command -v rustup &>/dev/null; then
     echo "Error: rustup could not be found! Exiting"

--- a/generate_test_coverage.sh
+++ b/generate_test_coverage.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Important note: This currently requires $CODECOV_TOKEN to be set before calling this
+# I'm ti
+exit_with_error() {
+    echo "Error: $*"
+    exit 1
+}
+# from https://stackoverflow.com/a/246128
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+if ! command -v rustup &>/dev/null; then
+    echo "Error: rustup could not be found! Exiting"
+    exit 1
+fi
+# Implicitly assumes that cargo is there if rustup is available
+if ! cargo profdata --help &>/dev/null; then
+    echo "Warning: cargo profdata not available. Attempting to install via rustup"
+    echo "This adds llvm-tools-preview and cargo-binutils."
+    # shellcheck disable=SC2015
+    rustup component add llvm-tools-preview &&
+        cargo install cargo-binutils &&
+        cargo profdata --help &>/dev/null ||
+        exit_with_error "Error when installing llvm-tools-preview or cargo-binutils"
+fi
+
+if ! rustfilt --version &>/dev/null; then
+    echo "rustfilt not found. It is required for demangling function names"
+    echo "Attempting to install rustfilt via cargo"
+    # shellcheck disable=SC2015
+    cargo install rustfilt \
+    && rustfilt --version &>/dev/null \
+    || exit_with_error "Failed to install rustfilt"
+fi
+
+if ! grcov --version &>/dev/null; then
+    echo "Grcov not found. Attempting to install via cargo"
+    # shellcheck disable=SC2015
+    cargo install grcov \
+    && grcov --version &>/dev/null \
+    || exit_with_error "Failed to install grcov"
+fi
+
+# Test coverage requires clean build, so that everything is instrumented
+cargo clean
+echo "Running cargo test. This may take a while."
+
+# Run tests and collect information about the filenames of the executables in json format
+TEST_JSON_OUTPUT="$(
+    RUSTFLAGS="-Zinstrument-coverage -Clink-dead-code" \
+        RUSTDOCFLAGS="-Zinstrument-coverage -Zunstable-options --persist-doctests  target/debug/doctestbins" \
+        LLVM_PROFILE_FILE="uhyve-%m.profraw" \
+        cargo test --message-format=json
+)"
+if [ $? != 0 ]; then
+    exit_with_error "Coverage run of cargo test failed." "$TEST_JSON_OUTPUT"
+fi
+echo "Finished cargo test successfully"
+cargo profdata -- merge -sparse uhyve-*.profraw -o uhyve.profdata \
+    || exit_with_error "Failed to merge raw profiling data"
+
+# Generate code coverage in coveralls JSON format
+grcov "$DIR" --source-dir "$DIR" \
+    --binary-path "$DIR/target/debug" \
+    --output-type coveralls \
+    --token "$CODECOV_TOKEN" > coveralls.json \
+ || exit_with_error "grcov did not successfully generate a coverage report"
+
+# Todo: make this whole part optional, since we might be only interested in coveralls report
+# Remove non JSON parts. Assumes all json lines start with '{' (valid for cargo output as of now)
+# but this may break sometime.
+FILTERED_TEST_JSON_OUTPUT=$(grep '^[\{]' <<<"$TEST_JSON_OUTPUT")
+# Get test executable names (adapted from https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html)
+JQ_OUTPUT=$(jq -r "select(.profile.test == true) | .filenames[]" <<<"$FILTERED_TEST_JSON_OUTPUT")
+JQ_RETURN=$?
+TEST_FILES=$(grep -v dSYM - <<<"$JQ_OUTPUT")
+GREP_RETURN=$?
+if [ $JQ_RETURN != 0 ]; then
+    jq_input=$(mktemp)
+    jq_output=$(mktemp)
+    echo "$FILTERED_TEST_JSON_OUTPUT" >"$jq_input"
+    echo "$JQ_OUTPUT" >"$jq_output"
+    echo "Error: using jq to parse test executable names from cargo output."
+    echo "The input json was dumped to  'file://$jq_input'."
+    echo "The Output of jq was dumped  'file://$jq_output'."
+    exit 1
+fi
+if [ $GREP_RETURN != 0 ]; then
+    echo "Grep reported an error - dumping output:"
+    echo "$TEST_FILES"
+    exit 1
+fi
+echo "Info: Detected the following Test executables: $TEST_FILES"
+
+DOC_TEST_BINS=("$DIR/target/debug/doctestbins/*/rust_out")
+# Generate options to pass paths to all test executables to llvm-cov
+CARGO_COV_OBJECTS=$( \
+    for file in $TEST_FILES $DOC_TEST_BINS; do \
+        [[ -x "$file" ]] \
+        && printf "%s %s " "-object" "$file" \
+        || exit_with_error "Error merging file $file"; \
+    done \
+)
+
+# Print summary on cmdline
+cargo cov -- report \
+    --use-color \
+    --ignore-filename-regex='/.cargo/registry' \
+    --instr-profile=uhyve.profdata \
+    $CARGO_COV_OBJECTS

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,11 @@ pub fn parse_mem(mem: &str) -> Result<usize> {
 	Ok(num * factor)
 }
 
+/// Example:
+/// ```rust
+/// # use uhyvelib::utils::parse_u32;
+/// assert_eq!(parse_u32("15").unwrap(), 15);
+/// ```
 pub fn parse_u32(s: &str) -> Result<u32> {
 	s.parse::<u32>().map_err(|_| Error::ParseMemory)
 }


### PR DESCRIPTION
This is #53 again. Creating this again, so that bors works.

This PR mainly adds a script that automates test coverage report generation.
To generate the report the binaries is instrumented by setting the RUSTFLAG -Zinstrument-coverage which enables source-based coverage.
I've tested and this works for both unit and doctests (Master currently does not have any doctests, I verified it with a doctest I added locally).

The test coverage generated is specific to the architecture, i.e. the coverage report generated on a Linux machine will not consider any of the code which is for macOS and it won't appear in the reports.
However codecov.io automatically merges reports from different architectures, so the report, that the codecov bot will hopefully link below, should show a complete picture.