### PR TITLE
prevent VM exits due to the pause instructions

### DIFF
--- a/src/linux/uhyve.rs
+++ b/src/linux/uhyve.rs
@@ -210,7 +210,7 @@ impl Uhyve {
 			..Default::default()
 		};
 		cap.args[0] =
-			(KVM_X2APIC_API_USE_32BIT_IDS | KVM_X2APIC_API_DISABLE_BROADCAST_QUIRK) as u64;
+			(KVM_X2APIC_API_USE_32BIT_IDS | KVM_X2APIC_API_DISABLE_BROADCAST_QUIRK).into();
 		vm.enable_cap(&cap)
 			.expect("Unable to enable x2apic support");
 
@@ -232,6 +232,15 @@ impl Uhyve {
 		if vm.enable_cap(&cap).is_ok() {
 			panic!("The support of KVM_CAP_IRQFD is curently required");
 		}
+
+		let mut cap: kvm_enable_cap = kvm_bindings::kvm_enable_cap {
+			cap: KVM_CAP_X86_DISABLE_EXITS,
+			flags: 0,
+			..Default::default()
+		};
+		cap.args[0] = KVM_X86_DISABLE_EXITS_PAUSE.into();
+		vm.enable_cap(&cap)
+			.expect("Unable to disable exists due pause instructions");
 
 		let evtfd = EventFd::new(0).unwrap();
 		vm.register_irqfd(&evtfd, UHYVE_IRQ_NET).or_else(to_error)?;


### PR DESCRIPTION
less VM exists should reduce the overhead