### PR TITLE
CI: Fix bors.toml status name

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
   "Build (ubuntu-latest, nightly)",
   "Build (macOS-latest, nightly)",
-  "Format (ubuntu-latest, nightly)",
+  "Format check (ubuntu-latest, nightly)",
   "Test (ubuntu-latest, nightly)",
   "Test (macOS-latest, nightly)",
   "ci/gitlab/git.rwth-aachen.de",


### PR DESCRIPTION
In uhyve the Job name for checking the formatting is called "Format check (ubuntu-latest, nightly)".
This should fix bors timing out.
cf name in:  https://github.com/hermitcore/uhyve/runs/1716087241