### PR TITLE
Added instrument feature using rftrace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,6 @@ jobs:
     - name: Build
       run:
          cargo build
+    - name: Build with instrument feature
+      run:
+         cargo clean && RUSTFLAGS="-Z instrument-mcount" cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "rftrace"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2ee2d77e97cb948eb4576a5b7908aac75c02afa337c99aa34b9cef0346bedd"
+
+[[package]]
+name = "rftrace-frontend"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419a5a276d688261074e7356d4061628dca7b0987f9422eeed4c66ecc128639a"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +803,8 @@ dependencies = [
  "nix",
  "nom",
  "raw-cpuid",
+ "rftrace",
+ "rftrace-frontend",
  "rustc-serialize",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ A hypervisor for RustyHermit
 
 exclude = ["/img/*", "./benches/*", "./benches_data/*", "./.github/workflows", "bors.toml", ".gitlab-ci.yml", "Dockerfile", ".gitignore", ".gitmodules", ".gitattributes"]
 
+[features]
+default = []
+instrument = ["rftrace", "rftrace-frontend"]
+
 [lib]
 name = "uhyvelib"
 path = "src/lib.rs"
@@ -43,6 +47,9 @@ strum_macros = "0.20.1"
 gdb-protocol = "0.1.0"
 burst = "0.0.2"
 core_affinity = "0.5.10"
+
+rftrace = {version = "0.1.0", optional = true}
+rftrace-frontend = {version = "0.1.0", optional = true}
 
 [dependencies.goblin]
 version = "0.3.0"

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -4,6 +4,11 @@ extern crate log;
 #[macro_use]
 extern crate clap;
 
+#[cfg(feature = "instrument")]
+extern crate rftrace;
+#[cfg(feature = "instrument")]
+extern crate rftrace_frontend;
+
 use std::env;
 use std::sync::atomic::spin_loop_hint;
 use std::sync::Arc;
@@ -20,7 +25,14 @@ use uhyvelib::utils::{filter_cpu_affinity, parse_cpu_affinity, parse_u32_range};
 const MINIMAL_GUEST_SIZE: usize = 16 * 1024 * 1024;
 const DEFAULT_GUEST_SIZE: usize = 64 * 1024 * 1024;
 
+// Note that we end main with `std::process::exit` to set the return value and
+// as a result destructors are not run and cleanup may not happen.
 fn main() {
+	#[cfg(feature = "instrument")]
+	let events = rftrace_frontend::init(1000000, true);
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::enable();
+
 	env_logger::init();
 
 	let matches = App::new("uhyve")
@@ -242,7 +254,7 @@ fn main() {
 			};
 
 			// create thread for each CPU
-			thread::spawn(move || {
+			thread::spawn(move || -> Option<i32> {
 				debug!("Create thread for CPU {}", tid);
 				match local_cpu_affinity {
 					Some(core_id) => {
@@ -264,16 +276,34 @@ fn main() {
 				// jump into the VM and excute code of the guest
 				let result = cpu.run();
 				match result {
-					Ok(()) => {}
 					Err(x) => {
 						error!("CPU {} crashes! {}", tid, x);
+						None
 					}
+					Ok(exit_code) => exit_code,
 				}
 			})
 		})
 		.collect();
 
+	let mut exit_code: Option<i32> = None;
 	for t in threads {
-		t.join().unwrap();
+		let exit_code_tid = t.join().unwrap();
+
+		if exit_code_tid.is_some() {
+			if exit_code.is_some() {
+				debug!("Found multiple exit code. Taking the laste one");
+			}
+			exit_code = exit_code_tid;
+		}
+	}
+
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::dump_full_uftrace(events, "uhyve_trace", "uhyve", true)
+		.expect("Saving trace failed");
+
+	match exit_code {
+		Some(a) => std::process::exit(a),
+		None => std::process::exit(0),
 	}
 }

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -285,7 +285,7 @@ impl VirtualCPU for UhyveCPU {
 		(entry & ((!0usize) << PAGE_BITS)) | (addr & !((!0usize) << PAGE_BITS))
 	}
 
-	fn run(&mut self) -> Result<()> {
+	fn run(&mut self) -> Result<Option<i32>> {
 		//self.print_registers();
 
 		// Pause first CPU before first execution, so we have time to attach debugger
@@ -361,7 +361,7 @@ impl VirtualCPU for UhyveCPU {
 					match port {
 						#![allow(clippy::cast_ptr_alignment)]
 						SHUTDOWN_PORT => {
-							return Ok(());
+							return Ok(None);
 						}
 						UHYVE_UART_PORT => {
 							self.uart(String::from_utf8_lossy(&addr).to_string())?;
@@ -386,7 +386,7 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_EXIT => {
 							let data_addr: usize =
 								unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-							self.exit(self.host_address(data_addr));
+							return Ok(Some(self.exit(self.host_address(data_addr))));
 						}
 						UHYVE_PORT_OPEN => {
 							let data_addr: usize =
@@ -474,7 +474,7 @@ impl VirtualCPU for UhyveCPU {
 			}
 		}
 
-		Ok(())
+		Ok(None)
 	}
 
 	fn print_registers(&self) {

--- a/src/macos/vcpu.rs
+++ b/src/macos/vcpu.rs
@@ -548,7 +548,7 @@ impl VirtualCPU for UhyveCPU {
 		(entry & ((!0usize) << PAGE_BITS)) | (addr & !((!0usize) << PAGE_BITS))
 	}
 
-	fn run(&mut self) -> Result<()> {
+	fn run(&mut self) -> Result<Option<i32>> {
 		//self.print_registers();
 
 		// Pause first CPU before first execution, so we have time to attach debugger
@@ -652,7 +652,7 @@ impl VirtualCPU for UhyveCPU {
 
 					match port {
 						SHUTDOWN_PORT => {
-							return Ok(());
+							return Ok(None);
 						}
 						UHYVE_UART_PORT => {
 							let al = (self.vcpu.read_register(&x86Reg::RAX)? & 0xFF) as u8;
@@ -677,7 +677,7 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_EXIT => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&x86Reg::RAX)? & 0xFFFFFFFF;
-							self.exit(self.host_address(data_addr as usize));
+							return Ok(Some(self.exit(self.host_address(data_addr as usize))));
 						}
 						UHYVE_PORT_OPEN => {
 							let data_addr: u64 =
@@ -728,6 +728,8 @@ impl VirtualCPU for UhyveCPU {
 				}
 			}
 		}
+
+		Ok(None)
 	}
 
 	fn print_registers(&self) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -235,7 +235,7 @@ struct SysUnlink {
 
 pub trait VirtualCPU {
 	fn init(&mut self, entry_point: u64) -> Result<()>;
-	fn run(&mut self) -> Result<()>;
+	fn run(&mut self) -> Result<Option<i32>>;
 	fn print_registers(&self);
 	fn host_address(&self, addr: usize) -> usize;
 	fn virt_to_phys(&self, addr: usize) -> usize;
@@ -366,9 +366,9 @@ pub trait VirtualCPU {
 		Ok(())
 	}
 
-	fn exit(&self, args_ptr: usize) -> ! {
+	fn exit(&self, args_ptr: usize) -> i32 {
 		let sysexit = unsafe { &*(args_ptr as *const SysExit) };
-		std::process::exit(sysexit.arg);
+		sysexit.arg
 	}
 
 	fn open(&self, args_ptr: usize) -> Result<()> {


### PR DESCRIPTION
Added `instrument` feature, which is disabled by default. It only works
if uhyve is compiled with `-Z instrument-mcount`. Furthermore I removed
the std::process::exit() call from uhyvelib so it is possible to write
the trace. The return value is not returned from `VirtualCPU::run()`.

Note that using rftrace may not be the best tool to trace uhyve as there
are various other tools available on a modern desktop OS, but can be
used to trace RustyHermit and using the same tool simplifies everything
a bit.