### PR TITLE
Add benchmarks using QEMU and rusty_demo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,6 @@ jobs:
     - name: Build with instrument feature
       run:
          cargo clean && RUSTFLAGS="-Z instrument-mcount" cargo build
+    - name: Compile, but don't run benchmarks
+      run:
+         cargo bench --no-run

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -6,7 +6,7 @@ mod vm;
 use crate::vm::load_kernel_benchmark_group;
 
 mod complete_binary;
-use crate::complete_binary::run_hello_world_group;
+use crate::complete_binary::run_complete_binaries_group;
 
 // Add the benchmark groups that should be run
-criterion_main!(load_kernel_benchmark_group, run_hello_world_group);
+criterion_main!(load_kernel_benchmark_group, run_complete_binaries_group);

--- a/benches/complete_binary/mod.rs
+++ b/benches/complete_binary/mod.rs
@@ -2,8 +2,25 @@ extern crate criterion;
 
 use criterion::{criterion_group, Criterion};
 
+use std::env;
+use std::fs;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::Duration;
+
+// based on https://stackoverflow.com/questions/35045996/check-if-a-command-is-in-path-executable-as-process#35046243
+// will fail on windows
+fn is_program_in_path(program: &str) -> bool {
+	if let Ok(path) = env::var("PATH") {
+		for p in path.split(":") {
+			let p_str = format!("{}/{}", p, program);
+			if fs::metadata(p_str).is_ok() {
+				return true;
+			}
+		}
+	}
+	false
+}
 
 pub fn run_hello_world(c: &mut Criterion) {
 	let uhyve_path = env!("CARGO_MANIFEST_DIR").to_string() + &"/target/release/uhyve".to_string();
@@ -19,7 +36,7 @@ pub fn run_hello_world(c: &mut Criterion) {
 		"hello_world executable missing from bench_data"
 	);
 
-	let mut group = c.benchmark_group("uhyve complete run");
+	let mut group = c.benchmark_group("hello_world");
 	group.sample_size(30);
 
 	group.bench_function("uhyve benches_data/hello_world", |b| {
@@ -32,6 +49,113 @@ pub fn run_hello_world(c: &mut Criterion) {
 			assert!(status.success());
 		})
 	});
+
+	let qemu_available = is_program_in_path("qemu-system-x86_64");
+
+	if !qemu_available {
+		println!("QEMU not available, skipping QEMU benchmark");
+		return;
+	}
+
+	let rusty_loader_path =
+		env!("CARGO_MANIFEST_DIR").to_string() + &"/benches_data/rusty-loader".to_string();
+	assert!(
+		Path::new(&rusty_loader_path).exists(),
+		"rusty-loader is missing from bench_data"
+	);
+
+	group.bench_function("qemu benches_data/hello_world", |b| {
+		b.iter(|| {
+			let status = Command::new("qemu-system-x86_64")
+				.arg("-smp")
+				.arg("1")
+				.arg("-m")
+				.arg("64M")
+				.arg("-kernel")
+				.arg(&rusty_loader_path)
+				.arg("-initrd")
+				.arg(&hello_world_path)
+				.arg("-display")
+				.arg("none")
+				.arg("-serial")
+				.arg("stdio")
+				.arg("-enable-kvm")
+				.arg("-cpu")
+				.arg("host")
+				.stdout(Stdio::null())
+				.status()
+				.expect("failed to execute process");
+			assert!(status.success());
+		})
+	});
 }
 
-criterion_group!(run_hello_world_group, run_hello_world);
+pub fn run_rusty_demo(c: &mut Criterion) {
+	let uhyve_path = env!("CARGO_MANIFEST_DIR").to_string() + &"/target/release/uhyve".to_string();
+	assert!(
+		Path::new(&uhyve_path).exists(),
+		"uhyve release build is required to run this benchmark"
+	);
+
+	let rusty_demo_path =
+		env!("CARGO_MANIFEST_DIR").to_string() + &"/benches_data/rusty_demo".to_string();
+	assert!(
+		Path::new(&rusty_demo_path).exists(),
+		"rusty_demo executable missing from bench_data"
+	);
+
+	let mut group = c.benchmark_group("rusty_demo");
+	group.measurement_time(Duration::from_secs(60));
+
+	group.bench_function("uhyve benches_data/rusty_demo", |b| {
+		b.iter(|| {
+			let status = Command::new(&uhyve_path)
+				.arg(&rusty_demo_path)
+				.stdout(Stdio::null())
+				.status()
+				.expect("failed to execute process");
+			assert!(status.success());
+		})
+	});
+
+	let qemu_available = is_program_in_path("qemu-system-x86_64");
+
+	if !qemu_available {
+		println!("QEMU not available, skipping  QEMU benchmark");
+		return;
+	}
+
+	let rusty_loader_path =
+		env!("CARGO_MANIFEST_DIR").to_string() + &"/benches_data/rusty-loader".to_string();
+	assert!(
+		Path::new(&rusty_loader_path).exists(),
+		"rusty-loader is missing from bench_data"
+	);
+
+	group.bench_function("qemu benches_data/rusty_demo", |b| {
+		b.iter(|| {
+			let status = Command::new("qemu-system-x86_64")
+				.arg("-smp")
+				.arg("1")
+				.arg("-m")
+				.arg("64M")
+				.arg("-kernel")
+				.arg(&rusty_loader_path)
+				.arg("-initrd")
+				.arg(&rusty_demo_path)
+				.arg("-display")
+				.arg("none")
+				.arg("-serial")
+				.arg("stdio")
+				.arg("-enable-kvm")
+				.arg("-cpu")
+				.arg("host")
+				.stdout(Stdio::null())
+				.status()
+				.expect("failed to execute process");
+			assert!(status.success());
+		})
+	});
+}
+
+criterion_group!(run_complete_binaries_group, run_hello_world, run_rusty_demo);

--- a/benches_data/rusty-loader
+++ b/benches_data/rusty-loader
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed97c250e5c1e577edc1ca53a00c6263d9c320c418a2d9dbf1991a69eaf707bc
+size 2217456

--- a/benches_data/rusty_demo
+++ b/benches_data/rusty_demo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b978c446f384851b272ad4eaac8ede00367d1a47c8d3b9aa0221977bff12165b
+size 2314512


### PR DESCRIPTION
This commit added 3 new benchmarks:
* running `rusty_demo` with uhyve
* running `hello_world` and `rusty_demo` with QEMU if QEMU is in $PATH

The QEMU benchmarks probably only work on a posix based system as
parsing $PATH expects `:` as the seperator between paths.

Fix #62