### PR TITLE
CI: Improve codecov project status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
 coverage:
   status:
     patch: off
+    project: 
+      default:
+        target: auto   # Require same coverage ratio as base (from PR base or parent commit)
+        # Allow a drop of 1%, to account for  fluctuations with regards to certain 
+        # lines sometimes being present and missing, and sometimes not compiled at all
+        threshold: 1% 


### PR DESCRIPTION
Don't fail the `codecov/project` status if coverage drops by at most 1%. 
Since some lines in uhyve are sometimes compiled, but not covered, and sometimes not compiled at all, there
is a certain base fluctuation regarding the "missing" lines.