### PR TITLE
Bump kvm bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,18 +362,18 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c07667561c3d12d77342baf28ca5d0f8c3ea2160778485640ec84a4571da2"
+checksum = "04936b66155d2b23a0df85c411c234b329206e548e1d7f94b8e47c66c87a8a4f"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158d15da895bddca8223fa31dc9e8b9317bdc2fbc4635dea8dd575fc40dae37f"
+checksum = "74058b16912c6723db02d4ca3ec919b73cd41512ccd3b6202cf91ae8d6c9dce5"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -878,9 +878,9 @@ checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cdd1d72e262bbfb014de65ada24c1ac50e10a2e3b1e8ec052df188c2ee5dfa"
+checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,13 +60,13 @@ features = ["elf64", "elf32", "endian_fd", "std"]
 version = "0.0.12"
 
 [target.'cfg(target_os = "linux")'.dependencies.kvm-ioctls]
-version = "0.6.0"
+version = "0.8.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.kvm-bindings]
-version = "0.3.0"
+version = "0.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.vmm-sys-util]
-version = "0.7.0"
+version = "0.8.0"
 
 [target.'cfg(target_os = "linux")'.dependencies.tun-tap]
 version = "0.1.2"

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -56,7 +56,7 @@ impl UhyveCPU {
 		//debug!("Setup cpuid");
 
 		let mut kvm_cpuid = KVM
-			.get_supported_cpuid(KVM_MAX_MSR_ENTRIES)
+			.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
 			.or_else(to_error)?;
 		let kvm_cpuid_entries = kvm_cpuid.as_mut_slice();
 		let i = kvm_cpuid_entries
@@ -151,7 +151,8 @@ impl UhyveCPU {
 		msr_entries[0].index = MSR_IA32_MISC_ENABLE;
 		msr_entries[0].data = 1;
 
-		let msrs = Msrs::from_entries(&msr_entries);
+		let msrs = Msrs::from_entries(&msr_entries)
+			.expect("Unable to create initial values for the machine specific registers");
 		self.vcpu.set_msrs(&msrs).or_else(to_error)?;
 
 		Ok(())


### PR DESCRIPTION
- Bump kvm-bindings from 0.3.0 to 0.4.0 ([Release notes](https://github.com/rust-vmm/kvm-bindings/releases))
- Bump kvm-ioctls from 0.6.0 to 0.8.0 ([Release notes](https://github.com/rust-vmm/kvm-ioctls/releases))
- Bump vmm-sys-util from 0.7.0 to 0.8.0 ([Release notes](https://github.com/rust-vmm/vmm-sys-util/releases))
- Adjustments to support the new KVM bindings
- unwrap results of Msrs::from_entries to get MSR entries
- using KVM_MAX_CPUID_ENTRIES to define the maximum number of CPU entries