### PR TITLE
Don't allocate when forwarding stdout

### DIFF
--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -365,7 +365,7 @@ impl VirtualCPU for UhyveCPU {
 							return Ok(None);
 						}
 						UHYVE_UART_PORT => {
-							self.uart(String::from_utf8_lossy(&addr).to_string())?;
+							self.uart(&addr).unwrap();
 						}
 						UHYVE_PORT_CMDSIZE => {
 							let data_addr: usize =

--- a/src/macos/vcpu.rs
+++ b/src/macos/vcpu.rs
@@ -691,10 +691,8 @@ impl VirtualCPU for UhyveCPU {
 						}
 						UHYVE_UART_PORT => {
 							let al = (self.vcpu.read_register(&x86Reg::RAX)? & 0xFF) as u8;
-							let mut msg = vec![];
-							msg.push(al);
 
-							self.uart(std::str::from_utf8(&msg).unwrap().to_string())?;
+							self.uart(&[al]).unwrap();
 							self.vcpu.write_register(&x86Reg::RIP, rip + len)?;
 						}
 						UHYVE_PORT_CMDSIZE => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -9,11 +9,12 @@ use log::{debug, error, warn};
 use nix::errno::errno;
 use raw_cpuid::CpuId;
 use std::convert::TryInto;
-use std::fs;
+use std::io::Write;
 use std::net::Ipv4Addr;
 use std::ptr::write;
 use std::time::{Duration, Instant, SystemTime};
 use std::{fmt, mem, slice};
+use std::{fs, io};
 
 use crate::consts::*;
 use crate::debug_manager::DebugManager;
@@ -446,11 +447,8 @@ pub trait VirtualCPU {
 		Ok(())
 	}
 
-	fn uart(&self, message: String) -> Result<()> {
-		print!("{}", message);
-		//io::stdout().flush().ok().expect("Could not flush stdout");
-
-		Ok(())
+	fn uart(&self, buf: &[u8]) -> io::Result<()> {
+		io::stdout().write_all(buf)
 	}
 }
 


### PR DESCRIPTION
This avoids heap allocations and allows writing non-UTF-8-data to stdout.