### PR TITLE
KVM-CI: Cleanup before cloning rusty-hermit

### DIFF
--- a/.github/workflows/kvm.yml
+++ b/.github/workflows/kvm.yml
@@ -37,6 +37,7 @@ jobs:
          kvm-ok
          cd $GITHUB_WORKSPACE
          cd ..
+         rm -rf rusty-hermit
          git clone --recurse-submodules https://github.com/hermitcore/rusty-hermit.git
     - name: KVM tests (debug)
       shell: bash
@@ -52,9 +53,3 @@ jobs:
          cd ../rusty-hermit
          cargo build -p rusty_demo --release
          RUST_LOG=debug $GITHUB_WORKSPACE/target/release/uhyve -v -c 1 target/x86_64-unknown-hermit/release/rusty_demo
-    - name: Cleanup environment
-      shell: bash
-      run: |
-         cd $GITHUB_WORKSPACE
-         cd ..
-         rm -rf rusty-hermit


### PR DESCRIPTION
I suspect, the reason for [recent CI failures](https://github.com/hermitcore/uhyve/runs/2830867215#step:7:35) is that a KVM-CI-run did not complete and clean up after itself. So why not clean up, before cloning?