### PR TITLE
CI: Don't run slow KVM tests on every PR

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,7 +3,6 @@ name: Clippy
 on:
   push:
     branches:
-      - master
       - staging
       - trying
   pull_request:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - staging
       - trying
 

--- a/.github/workflows/kvm.yml
+++ b/.github/workflows/kvm.yml
@@ -1,7 +1,6 @@
 name: KVM Tests
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/kvm.yml
+++ b/.github/workflows/kvm.yml
@@ -3,7 +3,6 @@ name: KVM Tests
 on:
   push:
     branches:
-      - master
       - staging
       - trying
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - staging
       - trying
   schedule:
-    - cron: '0 0 * * 6'
+    - cron: '0 3 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - staging
       - trying
   schedule:


### PR DESCRIPTION
It is still required via bors.