### PR TITLE
Pin nightly version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format check
+name: Format
 
 on:
   pull_request:
@@ -9,31 +9,15 @@ on:
       - trying
 
 jobs:
-  check:
-    name: Format check
+  format:
+    name: Format
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        rust: [nightly]
-        include:
-          - os: ubuntu-latest
-            rust: 'nightly'
-            components: 'rustfmt'
-            targets: 'x86_64-unknown-linux-gnu'
-
-
     steps:
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: ${{ matrix.rust }}
-          components: ${{ matrix.components || '' }}
-          targets: ${{ matrix.targets || '' }}
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Check Formatting
-        run: cargo fmt -- --check
-      - name: Check Integration Test Formatting
+      - uses: actions/checkout@v2
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup show
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Integration Test Format
         working-directory: ./tests/test-kernels
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/kvm.yml
+++ b/.github/workflows/kvm.yml
@@ -12,24 +12,12 @@ jobs:
   kvm:
     name: KVM Tests
     runs-on: [self-hosted]
-
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with: 
-         rust-version: nightly
-         components: 'rustfmt, clippy'
-         targets: 'x86_64-unknown-linux-gnu'
     - uses: actions/checkout@v2
-      with:
-         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
+    - name: Install toolchain from rust-toolchain.toml
+      run: rustup show
     - name: Build (debug)
-      run:
-         cargo build
-    - name: Build (release)
-      run:
-         cargo build --release
+      run: cargo build
     - name: Prepare test environment
       shell: bash
       run: |
@@ -46,6 +34,8 @@ jobs:
          cd ../rusty-hermit
          cargo build -p rusty_demo
          RUST_LOG=debug $GITHUB_WORKSPACE/target/debug/uhyve -v -c 1 target/x86_64-unknown-hermit/debug/rusty_demo
+    - name: Build (release)
+      run: cargo build --release
     - name: KVM tests (release)
       shell: bash
       run: |
@@ -57,17 +47,9 @@ jobs:
   kernel-tests:
     name: Rusty-Hermit Kernel Tests
     runs-on: [self-hosted]
-
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with:
-         rust-version: nightly
-         components: 'rustfmt, clippy'
-         targets: 'x86_64-unknown-linux-gnu'
     - uses: actions/checkout@v2
-      with:
-         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
+    - name: Install toolchain from rust-toolchain.toml
+      run: rustup show
     - name: Integration Tests
       run: cargo test --test '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,34 +14,13 @@ jobs:
   test:
     name: Cargo tests
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
-        os: [ubuntu-latest,macOS-latest]
-        rust: [nightly]
-        include:
-          - os: macOS-latest
-            rust: 'nightly'
-            components: 'rustfmt, clippy, rust-src'
-            targets: 'x86_64-apple-darwin'
-          - os: ubuntu-latest
-            rust: 'nightly'
-            components: 'rustfmt, clippy'
-            targets: 'x86_64-unknown-linux-musl'
-
-
+        os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with: 
-         rust-version: ${{ matrix.rust }}
-         components: ${{ matrix.components || '' }}
-         targets: ${{ matrix.targets || '' }}
     - uses: actions/checkout@v2
-      with:
-         submodules: true
-         fetch-depth: '0'
-    - name: Check Cargo availability
-      run: cargo --version
+    - name: Install toolchain from rust-toolchain.toml
+      run: rustup show
     - name: Test
       run: |
          cargo test --lib -- --nocapture --skip test_vm
@@ -50,63 +29,31 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
-        os: [ubuntu-latest,macOS-latest]
-        rust: [nightly]
-        include:
-          - os: macOS-latest
-            rust: 'nightly'
-            components: 'rustfmt, clippy, rust-src'
-            targets: 'x86_64-apple-darwin'
-          - os: ubuntu-latest
-            rust: 'nightly'
-            components: 'rustfmt, clippy'
-            targets: 'x86_64-unknown-linux-musl'
-
-
+        os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with:
-         rust-version: ${{ matrix.rust }}
-         components: ${{ matrix.components || '' }}
-         targets: ${{ matrix.targets || '' }}
     - uses: actions/checkout@v2
-      with:
-         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
+    - name: Install toolchain from rust-toolchain.toml
+      run: rustup show
     - name: Build
-      run:
-         cargo build
+      run: cargo build
     - name: Build with instrument feature
-      run:
-         cargo clean && RUSTFLAGS="-Z instrument-mcount" cargo build
+      run: cargo clean && RUSTFLAGS="-Z instrument-mcount" cargo build
     - name: Compile, but don't run benchmarks
-      run:
-         cargo bench --no-run
+      run: cargo bench --no-run
 
   kernel-tests:
     name: Rusty-Hermit Kernel based integration tests
     runs-on: [self-hosted]
-
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with:
-         rust-version: nightly
-         components: 'rustfmt, clippy'
-         targets: 'x86_64-unknown-linux-gnu'
     - uses: actions/checkout@v2
-      with:
-         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
+    - name: Install toolchain from rust-toolchain.toml
+      run: rustup show
     - name: Integration Tests
       run: cargo test --test '*'
     - name: Generate integration test coverage
-      run: |
-        ./generate_test_coverage.sh --print-coverage
+      run: ./generate_test_coverage.sh --print-coverage
     - name: Generate unit test coverage
       run: |
         #./generate_test_coverage.sh --print-coverage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2021-08-15"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
Today's nightly update broke integration tests somewhere in rusty-hermit.

This pins the nightly version.