### PR TITLE
Use concrete vCPU structs instead of trait objects

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -22,7 +22,10 @@ use nix::sys::{
 	signal::{signal, SigHandler, Signal},
 };
 
-use crate::{vm::Vm, Uhyve};
+use crate::{
+	vm::{VirtualCPU, Vm},
+	Uhyve,
+};
 
 lazy_static! {
 	static ref KVM: Kvm = Kvm::new().unwrap();

--- a/src/linux/uhyve.rs
+++ b/src/linux/uhyve.rs
@@ -8,7 +8,7 @@ use crate::linux::virtio::*;
 use crate::linux::{MemoryRegion, KVM};
 use crate::shared_queue::*;
 use crate::vm::HypervisorResult;
-use crate::vm::{BootInfo, Parameter, VirtualCPU, Vm};
+use crate::vm::{BootInfo, Parameter, Vm};
 use kvm_bindings::*;
 use kvm_ioctls::VmFd;
 use log::debug;
@@ -316,11 +316,11 @@ impl Vm for Uhyve {
 		self.path.clone()
 	}
 
-	fn create_cpu(&self, id: u32) -> HypervisorResult<Box<dyn VirtualCPU>> {
+	fn create_cpu(&self, id: u32) -> HypervisorResult<UhyveCPU> {
 		let vm_start = self.mem.host_address() as usize;
 		let tx = self.uhyve_device.as_ref().map(|dev| dev.tx.clone());
 
-		Ok(Box::new(UhyveCPU::new(
+		Ok(UhyveCPU::new(
 			id,
 			self.path.clone(),
 			self.vm.create_vcpu(id.try_into().unwrap())?,
@@ -328,7 +328,7 @@ impl Vm for Uhyve {
 			tx,
 			self.virtio_device.clone(),
 			self.dbg.as_ref().cloned(),
-		)))
+		))
 	}
 
 	fn set_boot_info(&mut self, header: *const BootInfo) {

--- a/src/linux/virtio.rs
+++ b/src/linux/virtio.rs
@@ -124,7 +124,7 @@ impl VirtioNetPciDevice {
 		//TODO: how to read packets without synchronization issues
 	}
 
-	pub fn handle_notify_output(&mut self, dest: &[u8], cpu: &dyn VirtualCPU) {
+	pub fn handle_notify_output(&mut self, dest: &[u8], cpu: &impl VirtualCPU) {
 		let tx_num = read_u16!(dest, 0);
 		if tx_num == 1 && self.read_status_reg() & STATUS_DRIVER_OK == STATUS_DRIVER_OK {
 			self.send_available_packets(cpu);
@@ -132,7 +132,7 @@ impl VirtioNetPciDevice {
 	}
 
 	// Sends packets using the tun_tap crate, subject to change
-	fn send_available_packets(&mut self, cpu: &dyn VirtualCPU) {
+	fn send_available_packets(&mut self, cpu: &impl VirtualCPU) {
 		let tx_queue = &mut self.virt_queues[TX_QUEUE];
 		let mut send_indices = Vec::new();
 		for index in tx_queue.avail_iter() {
@@ -264,7 +264,7 @@ impl VirtioNetPciDevice {
 	}
 
 	// Register virtqueue
-	pub fn write_pfn(&mut self, dest: &[u8], vcpu: &dyn VirtualCPU) {
+	pub fn write_pfn(&mut self, dest: &[u8], vcpu: &impl VirtualCPU) {
 		let status = self.read_status_reg();
 		if status & STATUS_FEATURES_OK != 0
 			&& status & STATUS_DRIVER_OK == 0

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -6,7 +6,10 @@ use std::{
 
 use core_affinity::CoreId;
 
-use crate::{vm::Vm, Uhyve};
+use crate::{
+	vm::{VirtualCPU, Vm},
+	Uhyve,
+};
 
 pub mod gdb;
 mod ioapic;

--- a/src/macos/uhyve.rs
+++ b/src/macos/uhyve.rs
@@ -2,7 +2,7 @@ use crate::debug_manager::DebugManager;
 use crate::macos::ioapic::IoApic;
 use crate::macos::vcpu::*;
 use crate::vm::HypervisorResult;
-use crate::vm::{BootInfo, Parameter, VirtualCPU, Vm};
+use crate::vm::{BootInfo, Parameter, Vm};
 use libc;
 use libc::c_void;
 use log::debug;
@@ -102,14 +102,14 @@ impl Vm for Uhyve {
 		self.path.clone()
 	}
 
-	fn create_cpu(&self, id: u32) -> HypervisorResult<Box<dyn VirtualCPU>> {
-		Ok(Box::new(UhyveCPU::new(
+	fn create_cpu(&self, id: u32) -> HypervisorResult<UhyveCPU> {
+		Ok(UhyveCPU::new(
 			id,
 			self.path.clone(),
 			self.guest_mem as usize,
 			self.ioapic.clone(),
 			self.dbg.as_ref().cloned(),
-		)))
+		))
 	}
 
 	fn get_ip(&self) -> Option<Ipv4Addr> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -19,6 +19,7 @@ use std::{fs, io};
 use thiserror::Error;
 
 use crate::consts::*;
+use crate::os::vcpu::UhyveCPU;
 use crate::os::HypervisorError;
 
 const MHZ_TO_HZ: u64 = 1000000;
@@ -484,7 +485,7 @@ pub trait Vm {
 	fn set_entry_point(&mut self, entry: u64);
 	fn get_entry_point(&self) -> u64;
 	fn kernel_path(&self) -> PathBuf;
-	fn create_cpu(&self, id: u32) -> HypervisorResult<Box<dyn VirtualCPU>>;
+	fn create_cpu(&self, id: u32) -> HypervisorResult<UhyveCPU>;
 	fn set_boot_info(&mut self, header: *const BootInfo);
 	fn cpu_online(&self) -> u32;
 	fn get_ip(&self) -> Option<Ipv4Addr>;


### PR DESCRIPTION
In https://github.com/hermitcore/uhyve/pull/164, I implement additional traits for `UhyveCPU` on linux, but not on macos.

To be able to use the trait impls, this makes the vCPU structs concrete instead of using trait objects.