### PR TITLE
Integration tests: Use default profile

### DIFF
--- a/tests/test-kernels/Cargo.toml
+++ b/tests/test-kernels/Cargo.toml
@@ -7,9 +7,3 @@ publish = false
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-sys = "0.1"
-
-[profile.release]
-opt-level = 3
-
-[profile.dev]
-opt-level = 1      # controls the `--opt-level` the compiler builds with


### PR DESCRIPTION
For easy integration tests of gdbstub, I need the `dev` `opt-level` to be 0.

On `release`, `opt-level` is 3 by default.