### PR TITLE
CI: Download Git-LFS files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: [self-hosted]
     steps:
     - uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install toolchain from rust-toolchain.toml
       run: rustup show
     - name: Integration Tests


### PR DESCRIPTION
This is required for the [`test_vm.*`](https://github.com/hermitcore/uhyve/blob/3b70087e3612e55ddce7888ce1b9fe91ca8596c9/src/vm.rs#L856-L907) to work correctly. Without this, they are not operating on the real files, but mere placeholders.

We need `git-lfs` to be installed on our runner for this.

Found via https://github.com/hermitcore/uhyve/pull/192.