### PR TITLE
CI: Capture test output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
       run: rustup show
     - name: Test
       run: |
-         cargo test --lib -- --nocapture --skip test_vm
-         cargo test --doc -- --nocapture
+        cargo test --lib -- --skip test_vm
+        cargo test --doc
 
   build:
     name: Build


### PR DESCRIPTION
This avoids GitHub check annotations about expected panics.

This reverts https://github.com/hermitcore/uhyve/commit/4e222b7ac023adff37b95d9e3790be4743d71f9a.