### PR TITLE
Make coverage non-blocking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,8 @@
 coverage:
   status:
-    patch: off
-    project: 
+    project:
       default:
-        target: auto   # Require same coverage ratio as base (from PR base or parent commit)
-        # Allow a drop of 1%, to account for  fluctuations with regards to certain 
-        # lines sometimes being present and missing, and sometimes not compiled at all
-        threshold: 1% 
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Extracted from https://github.com/hermitcore/uhyve/pull/193.

This would better reflect the fact that coverage is not blocking PRs.

See https://docs.codecov.com/docs/commit-status#branches