### PR TITLE
Fixup Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,8 +343,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
- "libc 0.2.102",
+ "cfg-if",
+ "libc",
  "wasi",
 ]
 
@@ -684,7 +684,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "libc 0.2.102",
+ "libc",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -931,8 +931,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
- "libc 0.2.102",
+ "cfg-if",
+ "libc",
  "rand",
  "redox_syscall",
  "remove_dir_all",


### PR DESCRIPTION
Merging

1. https://github.com/hermitcore/uhyve/pull/211
2. https://github.com/hermitcore/uhyve/pull/205

in that order made the lockfile inconsistent.

bors r+