### PR TITLE
Upgrade to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uhyve"
 version = "0.0.29"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen>"]
-edition = "2018"
+edition = "2021"
 description = "A hypervisor for RustyHermit."
 repository = "https://github.com/hermitcore/uhyve"
 license = "MIT/Apache-2.0"

--- a/src/arch/x86_64/registers/debug.rs
+++ b/src/arch/x86_64/registers/debug.rs
@@ -1,7 +1,5 @@
 //! Functions to read and write debug registers.
 
-use std::convert::{TryFrom, TryInto};
-
 use gdbstub::target::ext::{base::singlethread::StopReason, breakpoints::WatchKind};
 use x86_64::{
 	registers::debug::{

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -9,7 +9,6 @@ extern crate clap;
 extern crate rftrace_frontend;
 
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/src/linux/gdb/mod.rs
+++ b/src/linux/gdb/mod.rs
@@ -22,7 +22,7 @@ use kvm_bindings::{
 };
 use libc::EINVAL;
 use nix::sys::pthread::pthread_self;
-use std::{convert::TryInto, io::Read, net::TcpStream, sync::Once, thread, time::Duration};
+use std::{io::Read, net::TcpStream, sync::Once, thread, time::Duration};
 use x86_64::registers::debug::Dr6Flags;
 
 use crate::linux::{vcpu::UhyveCPU, KickSignal};

--- a/src/linux/gdb/regs.rs
+++ b/src/linux/gdb/regs.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs, X87FpuInternalRegs, F80};
 use kvm_bindings::{kvm_fpu, kvm_regs, kvm_sregs};
 use kvm_ioctls::VcpuFd;

--- a/src/linux/gdb/regs.rs
+++ b/src/linux/gdb/regs.rs
@@ -154,7 +154,9 @@ impl From<Fpu> for kvm_fpu {
 			last_dp
 		};
 
-		let xmm = IntoIterator::into_iter(fpu.xmm)
+		let xmm = fpu
+			.xmm
+			.into_iter()
 			.map(u128::to_ne_bytes)
 			.collect::<Vec<_>>()
 			.try_into()

--- a/src/linux/uhyve.rs
+++ b/src/linux/uhyve.rs
@@ -12,7 +12,6 @@ use kvm_bindings::*;
 use kvm_ioctls::VmFd;
 use log::debug;
 use nix::sys::mman::*;
-use std::convert::TryInto;
 use std::fmt;
 use std::hint;
 use std::mem;

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -7,7 +7,6 @@ use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use kvm_bindings::*;
 use kvm_ioctls::{VcpuExit, VcpuFd};
-use std::convert::TryInto;
 use std::path::Path;
 use std::path::PathBuf;
 use std::slice;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -7,7 +7,6 @@ use goblin::elf64::program_header::{PT_LOAD, PT_TLS};
 use goblin::elf64::reloc::*;
 use log::{debug, error, warn};
 use raw_cpuid::CpuId;
-use std::convert::TryInto;
 use std::io::Write;
 use std::net::Ipv4Addr;
 use std::os::unix::ffi::OsStrExt;


### PR DESCRIPTION
Depends on

* https://github.com/hermitcore/uhyve/pull/232 (because cargo on the integration tests parses the main Cargo.toml for some reason)