### PR TITLE
Remove x86 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,6 @@ dependencies = [
  "tun-tap",
  "virtio-bindings",
  "vmm-sys-util",
- "x86",
  "x86_64",
  "xhypervisor",
 ]
@@ -1231,17 +1230,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x86"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e85eb056bbe47f56d75dc0ccc5fe9c12211ed141292f4d7485d2a7c3dedda09"
-dependencies = [
- "bit_field",
- "bitflags",
- "raw-cpuid",
-]
 
 [[package]]
 name = "x86_64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,6 @@ xhypervisor = "0.0"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.14", default-features = false }
 
-[target.'cfg(all(target_arch = "x86_64", target_os = "macos"))'.dependencies]
-x86 = { version = "0.43", default-features = false }
-
 [dev-dependencies]
 assert_fs = "1"
 criterion = "0.3"


### PR DESCRIPTION
This is required for https://github.com/hermitcore/uhyve/issues/247.

The `x86` crate does not provide a configuration which can be compiled on the stable toolchain channel. The rest of uhyve has already been migrated to `x86_64`. The constants imported from `x86` have been inserted manually.