### PR TITLE
Revert "Linux: Use lld"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-  "-Z", "gcc-ld=lld",
-]


### PR DESCRIPTION
This reverts commit a02f3421c0ff4e14561fac62d685be4d27847c99.
This removes the use of an unstable flag.