### PR TITLE
add missing implementation of the hypercall UHYVE_PORT_EXIT

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -58,7 +58,7 @@ impl BootInfo {
 			cpu_online: 0,
 			possible_cpus: 0,
 			current_boot_id: 0,
-			uartport: UHYVE_UART_PORT,
+			uartport: UHYVE_UART_PORT as u32,
 			single_kernel: 1,
 			uhyve: 0,
 			hcip: [255, 255, 255, 255],

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -46,8 +46,5 @@ pub const UHYVE_PORT_NETSTAT: u16 = 0x700;
 pub const UHYVE_PORT_CMDSIZE: u16 = 0x740;
 pub const UHYVE_PORT_CMDVAL: u16 = 0x780;
 
-#[cfg(target_arch = "aarch64")]
-pub const UHYVE_UART_PORT: u32 = 0x800;
-#[cfg(target_arch = "x86_64")]
 pub const UHYVE_UART_PORT: u16 = 0x800;
 pub const UHYVE_PORT_UNLINK: u16 = 0x840;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![allow(unused_macros)]
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::useless-conversion)]
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![allow(unused_macros)]
 #![allow(clippy::missing_safety_doc)]
-#![allow(clippy::useless-conversion)]
+#![allow(clippy::useless_conversion)]
 
 #[macro_use]
 mod macros;

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -77,7 +77,9 @@ impl VirtualCPU for UhyveCPU {
 							}
 							UHYVE_PORT_EXIT => {
 								let data_addr = self.vcpu.read_register(Register::X8)?;
-								return Ok(VcpuStopReason::Exit(self.exit(self.host_address(data_addr as usize))));
+								return Ok(VcpuStopReason::Exit(
+									self.exit(self.host_address(data_addr as usize)),
+								));
 							}
 							_ => {
 								error!("Unable to handle exception {:?}", exception);

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -38,8 +38,6 @@ impl VirtualCPU for UhyveCPU {
 		self.vcpu.write_register(Register::CPSR, pstate.bits())?;
 		self.vcpu.write_register(Register::PC, entry_point)?;
 		self.vcpu.write_register(Register::X0, BOOT_INFO_ADDR)?;
-		self.vcpu
-			.write_system_register(SystemRegister::SP_EL1, BOOT_INFO_ADDR - 0x10)?;
 
 		self.print_registers();
 
@@ -120,6 +118,10 @@ impl VirtualCPU for UhyveCPU {
 			.vcpu
 			.read_system_register(SystemRegister::SP_EL1)
 			.unwrap();
+		let sctlr = self
+			.vcpu
+			.read_system_register(SystemRegister::SCTLR_EL1)
+			.unwrap();
 		let lr = self.vcpu.read_register(Register::LR).unwrap();
 		let x0 = self.vcpu.read_register(Register::X0).unwrap();
 		let x1 = self.vcpu.read_register(Register::X1).unwrap();
@@ -156,8 +158,8 @@ impl VirtualCPU for UhyveCPU {
 		println!("----------");
 		println!(
 			"PC : {:016x}   LR : {:016x}   CPSR: {:016x}\n\
-		     SP : {:016x}",
-			pc, lr, cpsr, sp
+		     SP : {:016x}   SCTLR : {:016x}",
+			pc, lr, cpsr, sp, sctlr
 		);
 		print!(
 			"x0 : {:016x}   x1 : {:016x}    x2 : {:016x}\n\

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -525,7 +525,11 @@ pub trait Vm {
 						.copy_from_slice(&buffer[kernel_start..kernel_end]);
 
 					if program_header.p_memsz > program_header.p_filesz {
-						vm_slice[region_end..region_end + (program_header.p_memsz - program_header.p_filesz) as usize].iter_mut().for_each(|x| *x = 0);
+						vm_slice[region_end
+							..region_end
+								+ (program_header.p_memsz - program_header.p_filesz) as usize]
+							.iter_mut()
+							.for_each(|x| *x = 0);
 					}
 
 					image_size = if is_dyn {
@@ -560,7 +564,9 @@ pub trait Vm {
 		elf.dynrelas.iter().for_each(|rela| match rela.r_type {
 			R_X86_64_RELATIVE | R_AARCH64_RELATIVE => {
 				let offset = (vm_mem as u64 + start_address + rela.r_offset) as *mut u64;
-				*offset = (start_address as i64 + rela.r_addend.unwrap_or(0)).try_into().unwrap();
+				*offset = (start_address as i64 + rela.r_addend.unwrap_or(0))
+					.try_into()
+					.unwrap();
 			}
 			_ => {
 				debug!("Unsupported relocation type {}", rela.r_type);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -452,7 +452,7 @@ pub trait Vm {
 		write(&mut (*boot_info).uhyve, 0x1); // announce uhyve
 		write(&mut (*boot_info).current_boot_id, 0);
 		if self.verbose() {
-			write(&mut (*boot_info).uartport, UHYVE_UART_PORT);
+			write(&mut (*boot_info).uartport, UHYVE_UART_PORT.into());
 		} else {
 			write(&mut (*boot_info).uartport, 0);
 		}
@@ -523,10 +523,9 @@ pub trait Vm {
 
 					vm_slice[region_start..region_end]
 						.copy_from_slice(&buffer[kernel_start..kernel_end]);
-					for i in &mut vm_slice[region_end
-						..region_end + (program_header.p_memsz - program_header.p_filesz) as usize]
-					{
-						*i = 0
+
+					if program_header.p_memsz > program_header.p_filesz {
+						vm_slice[region_end..region_end + (program_header.p_memsz - program_header.p_filesz) as usize].iter_mut().for_each(|x| *x = 0);
 					}
 
 					image_size = if is_dyn {
@@ -561,7 +560,7 @@ pub trait Vm {
 		elf.dynrelas.iter().for_each(|rela| match rela.r_type {
 			R_X86_64_RELATIVE | R_AARCH64_RELATIVE => {
 				let offset = (vm_mem as u64 + start_address + rela.r_offset) as *mut u64;
-				*offset = (start_address as i64 + rela.r_addend.unwrap_or(0)) as u64;
+				*offset = (start_address as i64 + rela.r_addend.unwrap_or(0)).try_into().unwrap();
 			}
 			_ => {
 				debug!("Unsupported relocation type {}", rela.r_type);


### PR DESCRIPTION
The hypercall was missing for MacOS on aarch64. 