### PR TITLE
VirtualCPU: Take descriptive arguments

### DIFF
--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -9,6 +9,7 @@ use crate::vm::SysExit;
 use crate::vm::SysOpen;
 use crate::vm::SysRead;
 use crate::vm::SysUnlink;
+use crate::vm::SysWrite;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use kvm_bindings::*;
@@ -399,7 +400,9 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_WRITE => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.write(self.host_address(data_addr))?;
+								let syswrite =
+									unsafe { &*(self.host_address(data_addr) as *const SysWrite) };
+								self.write(syswrite)?;
 							}
 							UHYVE_PORT_READ => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -2,6 +2,7 @@ use crate::consts::*;
 use crate::linux::virtio::*;
 use crate::linux::KVM;
 use crate::vm::HypervisorResult;
+use crate::vm::SysCmdsize;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use kvm_bindings::*;
@@ -356,7 +357,10 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_CMDSIZE => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.cmdsize(self.host_address(data_addr));
+								let syssize = unsafe {
+									&mut *(self.host_address(data_addr) as *mut SysCmdsize)
+								};
+								self.cmdsize(syssize);
 							}
 							UHYVE_PORT_CMDVAL => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -4,6 +4,7 @@ use crate::linux::KVM;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
+use crate::vm::SysExit;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -381,9 +382,9 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_EXIT => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								return Ok(VcpuStopReason::Exit(
-									self.exit(self.host_address(data_addr)),
-								));
+								let sysexit =
+									unsafe { &*(self.host_address(data_addr) as *const SysExit) };
+								return Ok(VcpuStopReason::Exit(self.exit(sysexit)));
 							}
 							UHYVE_PORT_OPEN => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -4,6 +4,7 @@ use crate::linux::KVM;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
+use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use kvm_bindings::*;
@@ -402,7 +403,10 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_UNLINK => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.unlink(self.host_address(data_addr));
+								let sysunlink = unsafe {
+									&mut *(self.host_address(data_addr) as *mut SysUnlink)
+								};
+								self.unlink(sysunlink);
 							}
 							UHYVE_PORT_LSEEK => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -5,6 +5,7 @@ use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
+use crate::vm::SysOpen;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -389,7 +390,9 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_OPEN => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.open(self.host_address(data_addr));
+								let sysopen =
+									unsafe { &mut *(self.host_address(data_addr) as *mut SysOpen) };
+								self.open(sysopen);
 							}
 							UHYVE_PORT_WRITE => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -3,6 +3,7 @@ use crate::linux::virtio::*;
 use crate::linux::KVM;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
+use crate::vm::SysCmdval;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use kvm_bindings::*;
@@ -365,7 +366,9 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_CMDVAL => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.cmdval(self.host_address(data_addr));
+								let syscmdval =
+									unsafe { &*(self.host_address(data_addr) as *const SysCmdval) };
+								self.cmdval(syscmdval);
 							}
 							UHYVE_PORT_NETWRITE => {
 								match &self.tx {

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -2,6 +2,7 @@ use crate::consts::*;
 use crate::linux::virtio::*;
 use crate::linux::KVM;
 use crate::vm::HypervisorResult;
+use crate::vm::SysClose;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
@@ -420,7 +421,10 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_CLOSE => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.close(self.host_address(data_addr));
+								let sysclose = unsafe {
+									&mut *(self.host_address(data_addr) as *mut SysClose)
+								};
+								self.close(sysclose);
 							}
 							//TODO:
 							PCI_CONFIG_DATA_PORT => {

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -7,6 +7,7 @@ use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
 use crate::vm::SysOpen;
+use crate::vm::SysRead;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -403,7 +404,9 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_READ => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.read(self.host_address(data_addr));
+								let sysread =
+									unsafe { &mut *(self.host_address(data_addr) as *mut SysRead) };
+								self.read(sysread);
 							}
 							UHYVE_PORT_UNLINK => {
 								let data_addr: usize =

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -6,6 +6,7 @@ use crate::vm::SysClose;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
+use crate::vm::SysLseek;
 use crate::vm::SysOpen;
 use crate::vm::SysRead;
 use crate::vm::SysUnlink;
@@ -422,7 +423,10 @@ impl VirtualCPU for UhyveCPU {
 							UHYVE_PORT_LSEEK => {
 								let data_addr: usize =
 									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
-								self.lseek(self.host_address(data_addr));
+								let syslseek = unsafe {
+									&mut *(self.host_address(data_addr) as *mut SysLseek)
+								};
+								self.lseek(syslseek);
 							}
 							UHYVE_PORT_CLOSE => {
 								let data_addr: usize =

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -7,6 +7,7 @@ use crate::aarch64::{
 };
 use crate::consts::*;
 use crate::vm::HypervisorResult;
+use crate::vm::SysExit;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use log::debug;
@@ -180,9 +181,10 @@ impl VirtualCPU for UhyveCPU {
 							}
 							UHYVE_PORT_EXIT => {
 								let data_addr = self.vcpu.read_register(Register::X8)?;
-								return Ok(VcpuStopReason::Exit(
-									self.exit(self.host_address(data_addr as usize)),
-								));
+								let sysexit = unsafe {
+									&*(self.host_address(data_addr as usize) as *const SysExit)
+								};
+								return Ok(VcpuStopReason::Exit(self.exit(sysexit)));
 							}
 							_ => {
 								error!("Unable to handle exception {:?}", exception);

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -5,6 +5,7 @@ use crate::macos::x86_64::ioapic::IoApic;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
+use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use burst::x86::{disassemble_64, InstructionOperation, OperandType};
@@ -796,7 +797,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_UNLINK => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.unlink(self.host_address(data_addr as usize));
+							let sysunlink = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysUnlink)
+							};
+							self.unlink(sysunlink);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_LSEEK => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -3,6 +3,7 @@
 use crate::consts::*;
 use crate::macos::x86_64::ioapic::IoApic;
 use crate::vm::HypervisorResult;
+use crate::vm::SysClose;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
@@ -818,7 +819,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_CLOSE => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.close(self.host_address(data_addr as usize));
+							let sysclose = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysClose)
+							};
+							self.close(sysclose);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						_ => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -7,6 +7,7 @@ use crate::vm::SysClose;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
+use crate::vm::SysLseek;
 use crate::vm::SysOpen;
 use crate::vm::SysRead;
 use crate::vm::SysUnlink;
@@ -821,7 +822,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_LSEEK => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.lseek(self.host_address(data_addr as usize));
+							let syslseek = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysLseek)
+							};
+							self.lseek(syslseek);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_CLOSE => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -4,6 +4,7 @@ use crate::consts::*;
 use crate::macos::x86_64::ioapic::IoApic;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
+use crate::vm::SysCmdval;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use burst::x86::{disassemble_64, InstructionOperation, OperandType};
@@ -761,7 +762,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_CMDVAL => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.cmdval(self.host_address(data_addr as usize));
+							let syscmdval = unsafe {
+								&*(self.host_address(data_addr as usize) as *const SysCmdval)
+							};
+							self.cmdval(syscmdval);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_EXIT => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -5,6 +5,7 @@ use crate::macos::x86_64::ioapic::IoApic;
 use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
+use crate::vm::SysExit;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -772,9 +773,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_EXIT => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							return Ok(VcpuStopReason::Exit(
-								self.exit(self.host_address(data_addr as usize)),
-							));
+							let sysexit = unsafe {
+								&*(self.host_address(data_addr as usize) as *const SysExit)
+							};
+							return Ok(VcpuStopReason::Exit(self.exit(sysexit)));
 						}
 						UHYVE_PORT_OPEN => {
 							let data_addr: u64 =

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -6,6 +6,7 @@ use crate::vm::HypervisorResult;
 use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
+use crate::vm::SysOpen;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -781,7 +782,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_OPEN => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.open(self.host_address(data_addr as usize));
+							let sysopen = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysOpen)
+							};
+							self.open(sysopen);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_WRITE => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -10,6 +10,7 @@ use crate::vm::SysExit;
 use crate::vm::SysOpen;
 use crate::vm::SysRead;
 use crate::vm::SysUnlink;
+use crate::vm::SysWrite;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use burst::x86::{disassemble_64, InstructionOperation, OperandType};
@@ -793,7 +794,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_WRITE => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.write(self.host_address(data_addr as usize)).unwrap();
+							let syswrite = unsafe {
+								&*(self.host_address(data_addr as usize) as *const SysWrite)
+							};
+							self.write(syswrite).unwrap();
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_READ => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -8,6 +8,7 @@ use crate::vm::SysCmdsize;
 use crate::vm::SysCmdval;
 use crate::vm::SysExit;
 use crate::vm::SysOpen;
+use crate::vm::SysRead;
 use crate::vm::SysUnlink;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
@@ -798,7 +799,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_READ => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.read(self.host_address(data_addr as usize));
+							let sysread = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysRead)
+							};
+							self.read(sysread);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_UNLINK => {

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -3,6 +3,7 @@
 use crate::consts::*;
 use crate::macos::x86_64::ioapic::IoApic;
 use crate::vm::HypervisorResult;
+use crate::vm::SysCmdsize;
 use crate::vm::VcpuStopReason;
 use crate::vm::VirtualCPU;
 use burst::x86::{disassemble_64, InstructionOperation, OperandType};
@@ -751,7 +752,10 @@ impl VirtualCPU for UhyveCPU {
 						UHYVE_PORT_CMDSIZE => {
 							let data_addr: u64 =
 								self.vcpu.read_register(&Register::RAX)? & 0xFFFFFFFF;
-							self.cmdsize(self.host_address(data_addr as usize));
+							let syssize = unsafe {
+								&mut *(self.host_address(data_addr as usize) as *mut SysCmdsize)
+							};
+							self.cmdsize(syssize);
 							self.vcpu.write_register(&Register::RIP, rip + len)?;
 						}
 						UHYVE_PORT_CMDVAL => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -57,7 +57,7 @@ pub struct SysOpen {
 }
 
 #[repr(C, packed)]
-struct SysLseek {
+pub struct SysLseek {
 	fd: i32,
 	offset: isize,
 	whence: i32,
@@ -303,9 +303,8 @@ pub trait VirtualCPU {
 	}
 
 	/// Handles an write syscall on the host.
-	fn lseek(&self, args_ptr: usize) {
+	fn lseek(&self, syslseek: &mut SysLseek) {
 		unsafe {
-			let syslseek = &mut *(args_ptr as *mut SysLseek);
 			syslseek.offset =
 				libc::lseek(syslseek.fd, syslseek.offset as i64, syslseek.whence) as isize;
 		}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -64,7 +64,7 @@ struct SysLseek {
 }
 
 #[repr(C, packed)]
-struct SysExit {
+pub struct SysExit {
 	arg: i32,
 }
 
@@ -239,8 +239,7 @@ pub trait VirtualCPU {
 	}
 
 	/// Reads the exit code from an VM and returns it
-	fn exit(&self, args_ptr: usize) -> i32 {
-		let sysexit = unsafe { &*(args_ptr as *const SysExit) };
+	fn exit(&self, sysexit: &SysExit) -> i32 {
 		sysexit.arg
 	}
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -74,7 +74,7 @@ const MAX_ARGC: usize = 128;
 const MAX_ENVC: usize = 128;
 
 #[repr(C, packed)]
-struct SysCmdsize {
+pub struct SysCmdsize {
 	argc: i32,
 	argsz: [i32; MAX_ARGC],
 	envc: i32,
@@ -143,8 +143,7 @@ pub trait VirtualCPU {
 
 	fn args(&self) -> &[OsString];
 
-	fn cmdsize(&self, args_ptr: usize) {
-		let syssize = unsafe { &mut *(args_ptr as *mut SysCmdsize) };
+	fn cmdsize(&self, syssize: &mut SysCmdsize) {
 		syssize.argc = 0;
 		syssize.envc = 0;
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -88,7 +88,7 @@ pub struct SysCmdval {
 }
 
 #[repr(C, packed)]
-struct SysUnlink {
+pub struct SysUnlink {
 	name: *const u8,
 	ret: i32,
 }
@@ -232,9 +232,8 @@ pub trait VirtualCPU {
 
 	/// unlink deletes a name from the filesystem. This is used to handle `unlink` syscalls from the guest.
 	/// TODO: UNSAFE AS *%@#. It has to be checked that the VM is allowed to unlink that file!
-	fn unlink(&self, args_ptr: usize) {
+	fn unlink(&self, sysunlink: &mut SysUnlink) {
 		unsafe {
-			let sysunlink = &mut *(args_ptr as *mut SysUnlink);
 			sysunlink.ret = libc::unlink(self.host_address(sysunlink.name as usize) as *const i8);
 		}
 	}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -43,7 +43,7 @@ struct SysRead {
 }
 
 #[repr(C, packed)]
-struct SysClose {
+pub struct SysClose {
 	fd: i32,
 	ret: i32,
 }
@@ -255,9 +255,8 @@ pub trait VirtualCPU {
 	}
 
 	/// Handles an close syscall by closing the file on the host.
-	fn close(&self, args_ptr: usize) {
+	fn close(&self, sysclose: &mut SysClose) {
 		unsafe {
-			let sysclose = &mut *(args_ptr as *mut SysClose);
 			sysclose.ret = libc::close(sysclose.fd);
 		}
 	}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -35,7 +35,7 @@ struct SysWrite {
 }
 
 #[repr(C, packed)]
-struct SysRead {
+pub struct SysRead {
 	fd: i32,
 	buf: *const u8,
 	len: usize,
@@ -262,9 +262,8 @@ pub trait VirtualCPU {
 	}
 
 	/// Handles an read syscall on the host.
-	fn read(&self, args_ptr: usize) {
+	fn read(&self, sysread: &mut SysRead) {
 		unsafe {
-			let sysread = &mut *(args_ptr as *mut SysRead);
 			let buffer = self.virt_to_phys(sysread.buf as usize);
 
 			let bytes_read = libc::read(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -82,7 +82,7 @@ pub struct SysCmdsize {
 }
 
 #[repr(C, packed)]
-struct SysCmdval {
+pub struct SysCmdval {
 	argv: *const u8,
 	envp: *const u8,
 }
@@ -174,8 +174,7 @@ pub trait VirtualCPU {
 	}
 
 	/// Copies the arguments end environment of the application into the VM's memory.
-	fn cmdval(&self, args_ptr: usize) {
-		let syscmdval = unsafe { &*(args_ptr as *const SysCmdval) };
+	fn cmdval(&self, syscmdval: &SysCmdval) {
 		let argv = self.host_address(syscmdval.argv as usize);
 
 		// copy kernel path as first argument

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -49,7 +49,7 @@ struct SysClose {
 }
 
 #[repr(C, packed)]
-struct SysOpen {
+pub struct SysOpen {
 	name: *const u8,
 	flags: i32,
 	mode: i32,
@@ -244,9 +244,8 @@ pub trait VirtualCPU {
 	}
 
 	/// Handles an open syscall by opening a file on the host.
-	fn open(&self, args_ptr: usize) {
+	fn open(&self, sysopen: &mut SysOpen) {
 		unsafe {
-			let sysopen = &mut *(args_ptr as *mut SysOpen);
 			sysopen.ret = libc::open(
 				self.host_address(sysopen.name as usize) as *const i8,
 				sysopen.flags,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -28,7 +28,7 @@ use crate::os::DebugExitInfo;
 use crate::os::HypervisorError;
 
 #[repr(C, packed)]
-struct SysWrite {
+pub struct SysWrite {
 	fd: i32,
 	buf: *const u8,
 	len: usize,
@@ -280,8 +280,7 @@ pub trait VirtualCPU {
 	}
 
 	/// Handles an write syscall on the host.
-	fn write(&self, args_ptr: usize) -> io::Result<()> {
-		let syswrite = unsafe { &*(args_ptr as *const SysWrite) };
+	fn write(&self, syswrite: &SysWrite) -> io::Result<()> {
 		let mut bytes_written: usize = 0;
 		let buffer = self.virt_to_phys(syswrite.buf as usize);
 


### PR DESCRIPTION
This PR moves the transmutes inside many `VirtualCPU` functions outside, moving the responsibility for a valid reference to the caller.