### PR TITLE
Bors: Don't require coverage

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -11,7 +11,6 @@ status = [
     "Clippy (x86_64, macos-latest)",
     "Clippy (aarch64, macos-latest)",
     "Clippy test-kernels",
-    "Coverage",
 ]
 delete_merged_branches = true
 timeout_sec = 7200


### PR DESCRIPTION
There seems to be a temporary downtime of some sorts.