### PR TITLE
Correctly set possible_cpus

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -527,7 +527,7 @@ pub trait Vm {
 			host_logical_addr: vm_mem as u64,
 			boot_gtod: n.as_micros().try_into().unwrap(),
 			cpu_freq: mhz,
-			possible_cpus: 1,
+			possible_cpus: self.num_cpus(),
 			uartport: self
 				.verbose()
 				.then(|| UHYVE_UART_PORT.into())


### PR DESCRIPTION
This was done correctly in caves uhyve: [`uhyve.c#L907`](https://github.com/hermitcore/hermit-caves/blob/e4b0302609c3bd47808bfc57f73178de32d90906/uhyve.c#L907)

Required for https://github.com/hermitcore/libhermit-rs/issues/506.