### PR TITLE
Add a hypercall to allow UART to accept a whole buffer

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -45,3 +45,4 @@ pub const UHYVE_PORT_CMDVAL: u16 = 0x780;
 
 pub const UHYVE_UART_PORT: u16 = 0x800;
 pub const UHYVE_PORT_UNLINK: u16 = 0x840;
+pub const UHYVE_UART_BUFFER_PORT: u16 = 0x880;

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -17,7 +17,7 @@ use crate::{
 	linux::{virtio::*, KVM},
 	vm::{
 		HypervisorResult, SysClose, SysCmdsize, SysCmdval, SysExit, SysLseek, SysOpen, SysRead,
-		SysUnlink, SysWrite, VcpuStopReason, VirtualCPU,
+		SysUart, SysUnlink, SysWrite, VcpuStopReason, VirtualCPU,
 	},
 };
 
@@ -366,6 +366,13 @@ impl VirtualCPU for UhyveCPU {
 						match port {
 							UHYVE_UART_PORT => {
 								self.uart(addr)?;
+							}
+							UHYVE_UART_BUFFER_PORT => {
+								let data_addr: usize =
+									unsafe { (*(addr.as_ptr() as *const u32)) as usize };
+								let sysuart =
+									unsafe { &mut *(self.host_address(data_addr) as *mut SysUart) };
+								self.uart_buffer(sysuart)?;
 							}
 							UHYVE_PORT_CMDSIZE => {
 								let data_addr: usize =

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -312,6 +312,13 @@ pub trait VirtualCPU {
 	fn uart(&self, buf: &[u8]) -> io::Result<()> {
 		io::stdout().write_all(buf)
 	}
+
+	/// Handles a UART syscall by contructing a buffer from parameter
+	fn uart_buffer(&self, sysuart: &SysUart) -> io::Result<()> {
+		let buf_addr = self.virt_to_phys(sysuart.buf as usize) as *const u8;
+		let buf = unsafe { std::slice::from_raw_parts(buf_addr, sysuart.len) };
+		io::stdout().write_all(buf)
+	}
 }
 
 pub trait Vm {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -86,6 +86,12 @@ pub struct SysUnlink {
 	ret: i32,
 }
 
+#[repr(C, packed)]
+pub struct SysUart {
+	buf: *const u8,
+	len: usize,
+}
+
 pub type HypervisorResult<T> = Result<T, HypervisorError>;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Addressing issue #455

Added a new UART hypercall (not replacing `UHYVE_UART_PORT`) that accepts a buffer of `u8`.

Hypercall uses a struct that contains the address of the buffer and the length of the buffer.
A slice of u8 is constructed from those fields and written to `stdout`.

The new handlers in each architecture module were modeled after the ones that already existed in that module.