### PR TITLE
Removed verbose flag. Fixes #496

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -41,10 +41,6 @@ fn setup_trace() {
 #[derive(Parser, Debug)]
 #[clap(version, author, about)]
 struct Args {
-	/// Print kernel messages
-	#[clap(short, long)]
-	verbose: bool,
-
 	#[clap(flatten, next_help_heading = "MEMORY")]
 	memory_args: MemoryArgs,
 
@@ -229,7 +225,6 @@ impl CpuArgs {
 impl From<Args> for Params {
 	fn from(args: Args) -> Self {
 		let Args {
-			verbose,
 			memory_args:
 				MemoryArgs {
 					memory_size,
@@ -251,7 +246,6 @@ impl From<Args> for Params {
 			kernel_args,
 		} = args;
 		Self {
-			verbose,
 			memory_size,
 			#[cfg(target_os = "linux")]
 			thp,

--- a/src/linux/uhyve.rs
+++ b/src/linux/uhyve.rs
@@ -130,7 +130,6 @@ pub struct Uhyve {
 	path: PathBuf,
 	args: Vec<OsString>,
 	boot_info: *const RawBootInfo,
-	verbose: bool,
 	uhyve_device: Option<UhyveNetwork>,
 	virtio_device: Arc<Mutex<VirtioNetPciDevice>>,
 	pub(super) gdb_port: Option<u16>,
@@ -145,7 +144,6 @@ impl fmt::Debug for Uhyve {
 			.field("num_cpus", &self.num_cpus)
 			.field("path", &self.path)
 			.field("boot_info", &self.boot_info)
-			.field("verbose", &self.verbose)
 			.field("uhyve_device", &self.uhyve_device)
 			.field("virtio_device", &self.virtio_device)
 			.finish()
@@ -260,7 +258,6 @@ impl Uhyve {
 			path: kernel_path,
 			args: params.kernel_args,
 			boot_info: ptr::null(),
-			verbose: params.verbose,
 			uhyve_device,
 			virtio_device,
 			gdb_port: params.gdb_port,
@@ -273,10 +270,6 @@ impl Uhyve {
 }
 
 impl Vm for Uhyve {
-	fn verbose(&self) -> bool {
-		self.verbose
-	}
-
 	fn set_offset(&mut self, offset: u64) {
 		self.offset = offset;
 	}

--- a/src/params.rs
+++ b/src/params.rs
@@ -10,9 +10,6 @@ use thiserror::Error;
 
 #[derive(Debug, Clone)]
 pub struct Params {
-	/// Print kernel messages
-	pub verbose: bool,
-
 	/// Guest RAM size
 	pub memory_size: GuestMemorySize,
 
@@ -43,7 +40,6 @@ pub struct Params {
 impl Default for Params {
 	fn default() -> Self {
 		Self {
-			verbose: Default::default(),
 			memory_size: Default::default(),
 			#[cfg(target_os = "linux")]
 			thp: false,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -316,7 +316,6 @@ pub trait Vm {
 	fn kernel_path(&self) -> &Path;
 	fn create_cpu(&self, id: u32) -> HypervisorResult<UhyveCPU>;
 	fn set_boot_info(&mut self, header: *const RawBootInfo);
-	fn verbose(&self) -> bool;
 	fn init_guest_mem(&self);
 
 	unsafe fn load_kernel(&mut self) -> LoadKernelResult<()> {
@@ -346,10 +345,10 @@ pub trait Vm {
 		let boot_info = BootInfo {
 			hardware_info: HardwareInfo {
 				phys_addr_range: arch::RAM_START..arch::RAM_START + vm_mem_len as u64,
-				serial_port_base: self.verbose().then(|| {
-					SerialPortBase::new((uhyve_interface::HypercallAddress::Uart as u16).into())
-						.unwrap()
-				}),
+
+				serial_port_base: SerialPortBase::new(
+					(uhyve_interface::HypercallAddress::Uart as u16).into(),
+				),
 				device_tree: None,
 			},
 			load_info,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -40,7 +40,6 @@ pub fn build_hermit_bin(kernel: impl AsRef<Path>) -> PathBuf {
 /// simple uhyve vm
 pub fn run_simple_vm(kernel_path: PathBuf) {
 	let params = Params {
-		verbose: true,
 		cpu_count: 2.try_into().unwrap(),
 		memory_size: Byte::from_bytes(32 * 1024 * 1024).try_into().unwrap(),
 		..Default::default()

--- a/tests/gdb.rs
+++ b/tests/gdb.rs
@@ -25,7 +25,6 @@ fn gdb() -> io::Result<()> {
 		let vm = Uhyve::new(
 			bin_path,
 			Params {
-				verbose: true,
 				gdb_port: Some(port),
 				..Default::default()
 			},


### PR DESCRIPTION
This completely removes the flag without any deprecation warning.
Thus it might break existing scripts which include `-v`.